### PR TITLE
Fix two linter bugs

### DIFF
--- a/src/lang-promql/parser/parser.test.ts
+++ b/src/lang-promql/parser/parser.test.ts
@@ -33,6 +33,23 @@ describe('Scalars and scalar-to-scalar operations', () => {
       expectedValueType: ValueType.scalar,
       expectedDiag: [] as Diagnostic[],
     },
+    {
+      expr: '2 * 3',
+      expectedValueType: ValueType.scalar,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'metric_name * "string"',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'binary expression must contain only scalar and instant vector types',
+          severity: 'error',
+          to: 11,
+        },
+      ] as Diagnostic[],
+    },
   ];
   testSuites.forEach((value) => {
     const state = createEditorState(value.expr);

--- a/src/lang-promql/parser/parser.ts
+++ b/src/lang-promql/parser/parser.ts
@@ -208,17 +208,14 @@ export class Parser {
         this.addDiagnostic(node, 'comparisons between other things than scalar cannot use BOOL modifier');
       }
     } else {
-      if (lt === ValueType.scalar && rt === ValueType.scalar) {
+      if (isComparisonOperator && lt === ValueType.scalar && rt === ValueType.scalar) {
         this.addDiagnostic(node, 'comparisons between scalars must use BOOL modifier');
       }
     }
     // TODO missing check regarding cardManyToOne or cardOneToMany
     // TODO missing check regarding the matching label
-    if (lt !== ValueType.scalar && lt !== ValueType.vector) {
+    if ([lt, rt].some((t) => t !== ValueType.scalar && t !== ValueType.vector)) {
       this.addDiagnostic(lExpr, 'binary expression must contain only scalar and instant vector types');
-    }
-    if (lt !== ValueType.scalar && lt !== ValueType.vector) {
-      this.addDiagnostic(rExpr, 'binary expression must contain only scalar and instant vector types');
     }
     if ((lt === ValueType.scalar || rt === ValueType.scalar) && isSetOperator) {
       this.addDiagnostic(node, 'set operator not allowed in binary scalar expression');


### PR DESCRIPTION
The following expression should be legal, but was not:

    1 * 2

The following expression should not be legal, but was:

    metric_name * "string"

Signed-off-by: Julius Volz <julius.volz@gmail.com>