### PR TITLE
Make snippet placeholders syntactically less problematic

### DIFF
--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -59,16 +59,16 @@ const autocompleteNode: { [key: string]: AutoCompleteNode } = {
 
 const snippets: readonly SnippetSpec[] = [
   {
-    keyword: 'sum(rate(<input vector>[5m]))',
-    snippet: 'sum(rate(${<input vector>}[5m]))',
+    keyword: 'sum(rate(__input_vector__[5m]))',
+    snippet: 'sum(rate(${__input_vector__}[5m]))',
   },
   {
-    keyword: 'histogram_quantile(<quantile>, sum by(le) (rate(<histogram metric>[5m])))',
-    snippet: 'histogram_quantile(${<quantile>}, sum by(le) (rate(${<histogram metric>}[5m])))',
+    keyword: 'histogram_quantile(__quantile__, sum by(le) (rate(__histogram_metric__[5m])))',
+    snippet: 'histogram_quantile(${__quantile__}, sum by(le) (rate(${__histogram_metric__}[5m])))',
   },
   {
-    keyword: 'label_replace(<input vector>, "<dst>", "<replacement>", "<src>", "<regex>")',
-    snippet: 'label_replace(${<input vector>}, "${<dst>}", "${<replacement>}", "${<src>}", "${<regex>}")',
+    keyword: 'label_replace(__input_vector__, "__dst__", "__replacement__", "__src__", "__regex__")',
+    snippet: 'label_replace(${__input_vector__}, "${__dst__}", "${__replacement__}", "${__src__}", "${__regex__}")',
   },
 ];
 


### PR DESCRIPTION
The current placeholders wrapped in <> brackets would cause the linter to
believe that all kinds of things were wrong, because < and > are also
binary operators. Furthermore, it actually leads to a JS error when wanting
to autocomplete in the second field of the histogram_quantile() snippet,
but I couldn't track down why yet. It's definitely linter-related though,
as the JS error only happens with the linter enabled. This change at least
avoids that common situation for now.

Signed-off-by: Julius Volz <julius.volz@gmail.com>