### PR TITLE
Add help info for Prom's built-in aggregation and function

### DIFF
--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -43,7 +43,7 @@ import { walkBackward, walkThrough } from '../parser/path-finder';
 import { aggregateOpModifierTerms, aggregateOpTerms, binOpModifierTerms, binOpTerms, functionIdentifierTerms, matchOpTerms } from './promql.terms';
 import { Completion, CompletionContext, CompletionResult, snippet } from '@codemirror/next/autocomplete';
 
-interface AutoCompleteNode {
+export interface AutoCompleteNode {
   label: string;
   detail?: string;
   info?: string;

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -43,7 +43,7 @@ import { walkBackward, walkThrough } from '../parser/path-finder';
 import { aggregateOpModifierTerms, aggregateOpTerms, binOpModifierTerms, binOpTerms, functionIdentifierTerms, matchOpTerms } from './promql.terms';
 import { Completion, CompletionContext, CompletionResult, snippet } from '@codemirror/next/autocomplete';
 
-export interface AutoCompleteNode {
+interface AutoCompleteNode {
   label: string;
   detail?: string;
   info?: string;

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -278,7 +278,7 @@ export const aggregateOpTerms = [
   {
     label: 'group',
     detail: 'aggregation',
-    info: 'All values in the resulting vector are 1',
+    info: 'Group series, while setting the sample value to 1'',
   },
   {
     label: 'max',

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -278,7 +278,7 @@ export const aggregateOpTerms = [
   {
     label: 'group',
     detail: 'aggregation',
-    info: 'Group series, while setting the sample value to 1'',
+    info: 'Group series, while setting the sample value to 1',
   },
   {
     label: 'max',

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -18,66 +18,254 @@ export const binOpTerms = [
 ];
 export const binOpModifierTerms = [{ label: 'on' }, { label: 'ignoring' }, { label: 'group_left' }, { label: 'group_right' }];
 export const functionIdentifierTerms = [
-  { label: 'abs' },
-  { label: 'absent' },
-  { label: 'absent_over_time' },
-  { label: 'avg_over_time' },
-  { label: 'ceil' },
-  { label: 'changes' },
-  { label: 'clamp_max' },
-  { label: 'clamp_min' },
-  { label: 'count_over_time' },
-  { label: 'days_in_month' },
-  { label: 'day_of_month' },
-  { label: 'day_of_week' },
-  { label: 'delta' },
-  { label: 'deriv' },
-  { label: 'exp' },
-  { label: 'floor' },
-  { label: 'histogram_quantile' },
-  { label: 'holt_winters' },
-  { label: 'hour' },
-  { label: 'idelta' },
-  { label: 'increase' },
-  { label: 'irate' },
-  { label: 'label_replace' },
-  { label: 'label_join' },
-  { label: 'ln' },
-  { label: 'log10' },
-  { label: 'log2' },
-  { label: 'max_over_time' },
-  { label: 'min_over_time' },
-  { label: 'minute' },
-  { label: 'month' },
-  { label: 'predict_linear' },
-  { label: 'quantile_over_time' },
-  { label: 'rate' },
-  { label: 'resets' },
-  { label: 'round' },
-  { label: 'scalar' },
-  { label: 'sort' },
-  { label: 'sort_desc' },
-  { label: 'sqrt' },
-  { label: 'stddev_over_time' },
-  { label: 'stdvar_over_time' },
-  { label: 'sum_over_time' },
-  { label: 'time' },
-  { label: 'timestamp' },
-  { label: 'vector' },
-  { label: 'year' },
+  {
+    label: 'abs',
+    info: 'Returns the input vector with all sample values converted to their absolute value.',
+  },
+  {
+    label: 'absent',
+    info:
+      'Returns an empty vector if the vector passed to it has any elements and a 1-element vector with the value 1 if the vector passed to it has no elements. This is useful for alerting on when no time series exist for a given metric name and label combination.',
+  },
+  {
+    label: 'absent_over_time',
+  },
+  {
+    label: 'avg_over_time',
+    info: 'The average value of all points in the specified interval.',
+  },
+  {
+    label: 'ceil',
+    info: 'Rounds the sample values of all elements in `v` up to the nearest integer.',
+  },
+  {
+    label: 'changes',
+    info:
+      'For each input time series, `changes(v range-vector)` returns the number of times its value has changed within the provided time range as an instant vector.',
+  },
+  {
+    label: 'clamp_max',
+    info: 'Clamps the sample values of all elements in `v` to have an upper limit of `max`.',
+  },
+  {
+    label: 'clamp_min',
+    info: 'Clamps the sample values of all elements in `v` to have a lower limit of `min`.',
+  },
+  {
+    label: 'count_over_time',
+    info: 'The count of all values in the specified interval.',
+  },
+  {
+    label: 'days_in_month',
+    info: 'Returns number of days in the month for each of the given times in UTC. Returned values are from 28 to 31.',
+  },
+  {
+    label: 'day_of_month',
+    info: 'Returns the day of the month for each of the given times in UTC. Returned values are from 1 to 31.',
+  },
+  {
+    label: 'day_of_week',
+    info: 'Returns the day of the week for each of the given times in UTC. Returned values are from 0 to 6, where 0 means Sunday etc.',
+  },
+  {
+    label: 'delta',
+    info:
+      'Calculates the difference between the first and last value of each time series element in a range vector `v`, returning an instant vector with the given deltas and equivalent labels. The delta is extrapolated to cover the full time range as specified in the range vector selector, so that it is possible to get a non-integer result even if the sample values are all integers.',
+  },
+  {
+    label: 'deriv',
+    info: 'Calculates the per-second derivative of the time series in a range vector `v`, using simple linear regression.',
+  },
+  {
+    label: 'exp',
+    info: 'Calculates the exponential function for all elements in `v`.\nSpecial cases are:\n* `Exp(+Inf) = +Inf` \n* `Exp(NaN) = NaN`',
+  },
+  {
+    label: 'floor',
+    info: 'Rounds the sample values of all elements in `v` down to the nearest integer.',
+  },
+  {
+    label: 'histogram_quantile',
+    info:
+      'Calculates the φ-quantile (0 ≤ φ ≤ 1) from the buckets `b` of a histogram. The samples in `b` are the counts of observations in each bucket. Each sample must have a label `le` where the label value denotes the inclusive upper bound of the bucket. (Samples without such a label are silently ignored.) The histogram metric type automatically provides time series with the `_bucket` suffix and the appropriate labels.',
+  },
+  {
+    label: 'holt_winters',
+    info:
+      'Produces a smoothed value for time series based on the range in `v`. The lower the smoothing factor `sf`, the more importance is given to old data. The higher the trend factor `tf`, the more trends in the data is considered. Both `sf` and `tf` must be between 0 and 1.',
+  },
+  {
+    label: 'hour',
+    info: 'Returns the hour of the day for each of the given times in UTC. Returned values are from 0 to 23.',
+  },
+  {
+    label: 'idelta',
+    info:
+      'Calculates the difference between the last two samples in the range vector `v`, returning an instant vector with the given deltas and equivalent labels.',
+  },
+  {
+    label: 'increase',
+    info:
+      'Calculates the increase in the time series in the range vector. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for. The increase is extrapolated to cover the full time range as specified in the range vector selector, so that it is possible to get a non-integer result even if a counter increases only by integer increments.',
+  },
+  {
+    label: 'irate',
+    info:
+      'Calculates the per-second instant rate of increase of the time series in the range vector. This is based on the last two data points. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for.',
+  },
+  {
+    label: 'label_replace',
+    info:
+      "For each timeseries in `v`, `label_replace(v instant-vector, dst_label string, replacement string, src_label string, regex string)`  matches the regular expression `regex` against the label `src_label`.  If it matches, then the timeseries is returned with the label `dst_label` replaced by the expansion of `replacement`. `$1` is replaced with the first matching subgroup, `$2` with the second etc. If the regular expression doesn't match then the timeseries is returned unchanged.",
+  },
+  {
+    label: 'label_join',
+  },
+  {
+    label: 'ln',
+    info:
+      'calculates the natural logarithm for all elements in `v`.\nSpecial cases are:\n * `ln(+Inf) = +Inf`\n * `ln(0) = -Inf`\n * `ln(x < 0) = NaN`\n * `ln(NaN) = NaN`',
+  },
+  {
+    label: 'log10',
+    info: 'Calculates the decimal logarithm for all elements in `v`. The special cases are equivalent to those in `ln`.',
+  },
+  {
+    label: 'log2',
+    info: 'Calculates the binary logarithm for all elements in `v`. The special cases are equivalent to those in `ln`.',
+  },
+  {
+    label: 'max_over_time',
+    info: 'The maximum value of all points in the specified interval.',
+  },
+  {
+    label: 'min_over_time',
+    info: 'The minimum value of all points in the specified interval.',
+  },
+  {
+    label: 'minute',
+    info: 'Returns the minute of the hour for each of the given times in UTC. Returned values are from 0 to 59.',
+  },
+  {
+    label: 'month',
+    info: 'Returns the month of the year for each of the given times in UTC. Returned values are from 1 to 12, where 1 means January etc.',
+  },
+  {
+    label: 'predict_linear',
+    info: 'Predicts the value of time series `t` seconds from now, based on the range vector `v`, using simple linear regression.',
+  },
+  {
+    label: 'quantile_over_time',
+    info: 'The φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.',
+  },
+  {
+    label: 'rate',
+    info:
+      "Calculates the per-second average rate of increase of the time series in the range vector. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for. Also, the calculation extrapolates to the ends of the time range, allowing for missed scrapes or imperfect alignment of scrape cycles with the range's time period.",
+  },
+  {
+    label: 'resets',
+    info:
+      'For each input time series, `resets(v range-vector)` returns the number of counter resets within the provided time range as an instant vector. Any decrease in the value between two consecutive samples is interpreted as a counter reset.',
+  },
+  {
+    label: 'round',
+    info:
+      'Rounds the sample values of all elements in `v` to the nearest integer. Ties are resolved by rounding up. The optional `to_nearest` argument allows specifying the nearest multiple to which the sample values should be rounded. This multiple may also be a fraction.',
+  },
+  {
+    label: 'scalar',
+    info:
+      'Given a single-element input vector, `scalar(v instant-vector)` returns the sample value of that single element as a scalar. If the input vector does not have exactly one element, `scalar` will return `NaN`.',
+  },
+  {
+    label: 'sort',
+    info: 'Returns vector elements sorted by their sample values, in ascending order.',
+  },
+  {
+    label: 'sort_desc',
+    info: 'Returns vector elements sorted by their sample values, in descending order.',
+  },
+  {
+    label: 'sqrt',
+    info: 'Calculates the square root of all elements in `v`.',
+  },
+  {
+    label: 'stddev_over_time',
+    info: 'The population standard deviation of the values in the specified interval.',
+  },
+  {
+    label: 'stdvar_over_time',
+    info: 'The population standard variance of the values in the specified interval.',
+  },
+  {
+    label: 'sum_over_time',
+    info: 'The sum of all values in the specified interval.',
+  },
+  {
+    label: 'time',
+    info:
+      'Returns the number of seconds since January 1, 1970 UTC. Note that this does not actually return the current time, but the time at which the expression is to be evaluated.',
+  },
+  {
+    label: 'timestamp',
+  },
+  {
+    label: 'vector',
+    info: 'Returns the scalar `s` as a vector with no labels.',
+  },
+  {
+    label: 'year',
+    info: 'Returns the year for each of the given times in UTC.',
+  },
 ];
 export const aggregateOpTerms = [
-  { label: 'avg' },
-  { label: 'bottomk' },
-  { label: 'count' },
-  { label: 'count_values' },
-  { label: 'group' },
-  { label: 'max' },
-  { label: 'min' },
-  { label: 'quantile' },
-  { label: 'stddev' },
-  { label: 'stdvar' },
-  { label: 'sum' },
-  { label: 'topk' },
+  {
+    label: 'avg',
+    info: 'Calculate the average over dimensions',
+  },
+  {
+    label: 'bottomk',
+    info: 'Smallest k elements by sample value',
+  },
+  {
+    label: 'count',
+    info: 'Count number of elements in the vector',
+  },
+  {
+    label: 'count_values',
+    info: 'Count number of elements with the same value',
+  },
+  {
+    label: 'group',
+  },
+  {
+    label: 'max',
+    info: 'Select maximum over dimensions',
+  },
+  {
+    label: 'min',
+    info: 'Select minimum over dimensions',
+  },
+  {
+    label: 'quantile',
+    info: 'Calculate φ-quantile (0 ≤ φ ≤ 1) over dimensions',
+  },
+  {
+    label: 'stddev',
+    info: 'Calculate population standard deviation over dimensions',
+  },
+  {
+    label: 'stdvar',
+    info: 'Calculate population standard variance over dimensions',
+  },
+  {
+    label: 'sum',
+    info: 'Calculate sum over dimensions',
+  },
+  {
+    label: 'topk',
+    info: 'Largest k elements by sample value',
+  },
 ];
 export const aggregateOpModifierTerms = [{ label: 'by' }, { label: 'without' }];

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -1,3 +1,5 @@
+import { AutoCompleteNode } from './hybrid';
+
 export const matchOpTerms = [{ label: '=' }, { label: '!=' }, { label: '=~' }, { label: '!~' }];
 export const binOpTerms = [
   { label: '^' },
@@ -17,7 +19,7 @@ export const binOpTerms = [
   { label: 'unless' },
 ];
 export const binOpModifierTerms = [{ label: 'on' }, { label: 'ignoring' }, { label: 'group_left' }, { label: 'group_right' }];
-export const functionIdentifierTerms = [
+export const functionIdentifierTerms: AutoCompleteNode[] = [
   {
     label: 'abs',
     info: 'Returns the input vector with all sample values converted to their absolute value.',
@@ -219,7 +221,10 @@ export const functionIdentifierTerms = [
     info: 'Returns the year for each of the given times in UTC.',
   },
 ];
-export const aggregateOpTerms = [
+functionIdentifierTerms.forEach((term) => {
+  term.detail = 'function';
+});
+export const aggregateOpTerms: AutoCompleteNode[] = [
   {
     label: 'avg',
     info: 'Calculate the average over dimensions',
@@ -268,4 +273,8 @@ export const aggregateOpTerms = [
     info: 'Largest k elements by sample value',
   },
 ];
+aggregateOpTerms.forEach((term) => {
+  term.detail = 'aggregation';
+});
+
 export const aggregateOpModifierTerms = [{ label: 'by' }, { label: 'without' }];

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -22,203 +22,191 @@ export const binOpModifierTerms = [{ label: 'on' }, { label: 'ignoring' }, { lab
 export const functionIdentifierTerms: AutoCompleteNode[] = [
   {
     label: 'abs',
-    info: 'Returns the input vector with all sample values converted to their absolute value.',
+    info: 'Return absolute values of input series',
   },
   {
     label: 'absent',
-    info:
-      'Returns an empty vector if the vector passed to it has any elements and a 1-element vector with the value 1 if the vector passed to it has no elements. This is useful for alerting on when no time series exist for a given metric name and label combination.',
+    info: 'Determine whether input vector is empty',
   },
   {
     label: 'absent_over_time',
+    info: 'Determine whether input range vector is empty',
   },
   {
     label: 'avg_over_time',
-    info: 'The average value of all points in the specified interval.',
+    info: 'Average series values over time',
   },
   {
     label: 'ceil',
-    info: 'Rounds the sample values of all elements in `v` up to the nearest integer.',
+    info: 'Round up values of input series to nearest integer',
   },
   {
     label: 'changes',
-    info:
-      'For each input time series, `changes(v range-vector)` returns the number of times its value has changed within the provided time range as an instant vector.',
+    info: 'Return number of value changes in input series over time',
   },
   {
     label: 'clamp_max',
-    info: 'Clamps the sample values of all elements in `v` to have an upper limit of `max`.',
+    info: 'Limit the value of input series to a maximum',
   },
   {
     label: 'clamp_min',
-    info: 'Clamps the sample values of all elements in `v` to have a lower limit of `min`.',
+    info: 'Limit the value of input series to a minimum',
   },
   {
     label: 'count_over_time',
-    info: 'The count of all values in the specified interval.',
+    info: 'Count the number of values for each input series',
   },
   {
     label: 'days_in_month',
-    info: 'Returns number of days in the month for each of the given times in UTC. Returned values are from 28 to 31.',
+    info: 'Return the number of days in current month for provided timestamps',
   },
   {
     label: 'day_of_month',
-    info: 'Returns the day of the month for each of the given times in UTC. Returned values are from 1 to 31.',
+    info: 'Return the day of the month for provided timestamps',
   },
   {
     label: 'day_of_week',
-    info: 'Returns the day of the week for each of the given times in UTC. Returned values are from 0 to 6, where 0 means Sunday etc.',
+    info: 'Return the day of the week for provided timestamps',
   },
   {
     label: 'delta',
-    info:
-      'Calculates the difference between the first and last value of each time series element in a range vector `v`, returning an instant vector with the given deltas and equivalent labels. The delta is extrapolated to cover the full time range as specified in the range vector selector, so that it is possible to get a non-integer result even if the sample values are all integers.',
+    info: 'Calculate the difference between beginning and end of a range vector (for gauges)',
   },
   {
     label: 'deriv',
-    info: 'Calculates the per-second derivative of the time series in a range vector `v`, using simple linear regression.',
+    info: 'Calculate the per-second derivative over series in a range vector (for gauges)',
   },
   {
     label: 'exp',
-    info: 'Calculates the exponential function for all elements in `v`.\nSpecial cases are:\n* `Exp(+Inf) = +Inf` \n* `Exp(NaN) = NaN`',
+    info: 'Calculate exponential function for input vector values',
   },
   {
     label: 'floor',
-    info: 'Rounds the sample values of all elements in `v` down to the nearest integer.',
+    info: 'Round down values of input series to nearest integer',
   },
   {
     label: 'histogram_quantile',
-    info:
-      'Calculates the φ-quantile (0 ≤ φ ≤ 1) from the buckets `b` of a histogram. The samples in `b` are the counts of observations in each bucket. Each sample must have a label `le` where the label value denotes the inclusive upper bound of the bucket. (Samples without such a label are silently ignored.) The histogram metric type automatically provides time series with the `_bucket` suffix and the appropriate labels.',
+    info: 'Calculate quantiles from histogram buckets',
   },
   {
     label: 'holt_winters',
-    info:
-      'Produces a smoothed value for time series based on the range in `v`. The lower the smoothing factor `sf`, the more importance is given to old data. The higher the trend factor `tf`, the more trends in the data is considered. Both `sf` and `tf` must be between 0 and 1.',
+    info: 'Calculate smoothed value of input series',
   },
   {
     label: 'hour',
-    info: 'Returns the hour of the day for each of the given times in UTC. Returned values are from 0 to 23.',
+    info: 'Return the hour of the day for provided timestamps',
   },
   {
     label: 'idelta',
-    info:
-      'Calculates the difference between the last two samples in the range vector `v`, returning an instant vector with the given deltas and equivalent labels.',
+    info: 'Calculate the difference between the last two samples of a range vector (for counters)',
   },
   {
     label: 'increase',
-    info:
-      'Calculates the increase in the time series in the range vector. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for. The increase is extrapolated to cover the full time range as specified in the range vector selector, so that it is possible to get a non-integer result even if a counter increases only by integer increments.',
+    info: 'Calculate the increase in value over a range of time (for counters)',
   },
   {
     label: 'irate',
-    info:
-      'Calculates the per-second instant rate of increase of the time series in the range vector. This is based on the last two data points. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for.',
+    info: 'Calculate the per-second increase over the last two samples of a range vector (for counters)',
   },
   {
     label: 'label_replace',
-    info:
-      "For each timeseries in `v`, `label_replace(v instant-vector, dst_label string, replacement string, src_label string, regex string)`  matches the regular expression `regex` against the label `src_label`.  If it matches, then the timeseries is returned with the label `dst_label` replaced by the expansion of `replacement`. `$1` is replaced with the first matching subgroup, `$2` with the second etc. If the regular expression doesn't match then the timeseries is returned unchanged.",
+    info: 'Set or replace label values',
   },
   {
     label: 'label_join',
+    info: 'Join together label values into new label',
   },
   {
     label: 'ln',
-    info:
-      'calculates the natural logarithm for all elements in `v`.\nSpecial cases are:\n * `ln(+Inf) = +Inf`\n * `ln(0) = -Inf`\n * `ln(x < 0) = NaN`\n * `ln(NaN) = NaN`',
+    info: 'Calculate natural logarithm of input series',
   },
   {
     label: 'log10',
-    info: 'Calculates the decimal logarithm for all elements in `v`. The special cases are equivalent to those in `ln`.',
+    info: 'Calulcate base-10 logarithm of input series',
   },
   {
     label: 'log2',
-    info: 'Calculates the binary logarithm for all elements in `v`. The special cases are equivalent to those in `ln`.',
+    info: 'Calculate base-2 logarithm of input series',
   },
   {
     label: 'max_over_time',
-    info: 'The maximum value of all points in the specified interval.',
+    info: 'Return the maximum value over time for input series',
   },
   {
     label: 'min_over_time',
-    info: 'The minimum value of all points in the specified interval.',
+    info: 'Return the minimum value over time for input series',
   },
   {
     label: 'minute',
-    info: 'Returns the minute of the hour for each of the given times in UTC. Returned values are from 0 to 59.',
+    info: 'Return the minute of the hour for provided timestamps',
   },
   {
     label: 'month',
-    info: 'Returns the month of the year for each of the given times in UTC. Returned values are from 1 to 12, where 1 means January etc.',
+    info: 'Return the month for provided timestamps',
   },
   {
     label: 'predict_linear',
-    info: 'Predicts the value of time series `t` seconds from now, based on the range vector `v`, using simple linear regression.',
+    info: 'Predict the value of a gauge into the future',
   },
   {
     label: 'quantile_over_time',
-    info: 'The φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.',
+    info: 'Calculate value quantiles over time for input series',
   },
   {
     label: 'rate',
-    info:
-      "Calculates the per-second average rate of increase of the time series in the range vector. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for. Also, the calculation extrapolates to the ends of the time range, allowing for missed scrapes or imperfect alignment of scrape cycles with the range's time period.",
+    info: 'Calculate per-second increase over a range vector (for counters)',
   },
   {
     label: 'resets',
-    info:
-      'For each input time series, `resets(v range-vector)` returns the number of counter resets within the provided time range as an instant vector. Any decrease in the value between two consecutive samples is interpreted as a counter reset.',
+    info: 'Return number of value decreases (resets) in input series of time',
   },
   {
     label: 'round',
-    info:
-      'Rounds the sample values of all elements in `v` to the nearest integer. Ties are resolved by rounding up. The optional `to_nearest` argument allows specifying the nearest multiple to which the sample values should be rounded. This multiple may also be a fraction.',
+    info: 'Round values of input series to nearest integer',
   },
   {
     label: 'scalar',
-    info:
-      'Given a single-element input vector, `scalar(v instant-vector)` returns the sample value of that single element as a scalar. If the input vector does not have exactly one element, `scalar` will return `NaN`.',
+    info: 'Convert single-element series vector into scalar value',
   },
   {
     label: 'sort',
-    info: 'Returns vector elements sorted by their sample values, in ascending order.',
+    info: 'Sort input series ascendingly by value',
   },
   {
     label: 'sort_desc',
-    info: 'Returns vector elements sorted by their sample values, in descending order.',
+    info: 'Sort input series descendingly by value',
   },
   {
     label: 'sqrt',
-    info: 'Calculates the square root of all elements in `v`.',
+    info: 'Return the square root for input series',
   },
   {
     label: 'stddev_over_time',
-    info: 'The population standard deviation of the values in the specified interval.',
+    info: 'Calculate the standard deviation within input series over time',
   },
   {
     label: 'stdvar_over_time',
-    info: 'The population standard variance of the values in the specified interval.',
+    info: 'Calculate the standard variation within input series over time',
   },
   {
     label: 'sum_over_time',
-    info: 'The sum of all values in the specified interval.',
+    info: 'Calculate the sum over the values of input series over time',
   },
   {
     label: 'time',
-    info:
-      'Returns the number of seconds since January 1, 1970 UTC. Note that this does not actually return the current time, but the time at which the expression is to be evaluated.',
+    info: 'Return the Unix timestamp at the current evaluation time',
   },
   {
     label: 'timestamp',
+    info: 'Return the Unix timestamp for the samples in the input vector',
   },
   {
     label: 'vector',
-    info: 'Returns the scalar `s` as a vector with no labels.',
+    info: 'Convert a scalar value into a single-element series vector',
   },
   {
     label: 'year',
-    info: 'Returns the year for each of the given times in UTC.',
+    info: 'Return the year for provided timestamps',
   },
 ];
 functionIdentifierTerms.forEach((term) => {

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -243,6 +243,7 @@ export const aggregateOpTerms: AutoCompleteNode[] = [
   },
   {
     label: 'group',
+    info: 'All values in the resulting vector are 1',
   },
   {
     label: 'max',

--- a/src/lang-promql/complete/promql.terms.ts
+++ b/src/lang-promql/complete/promql.terms.ts
@@ -1,5 +1,3 @@
-import { AutoCompleteNode } from './hybrid';
-
 export const matchOpTerms = [{ label: '=' }, { label: '!=' }, { label: '=~' }, { label: '!~' }];
 export const binOpTerms = [
   { label: '^' },
@@ -19,251 +17,304 @@ export const binOpTerms = [
   { label: 'unless' },
 ];
 export const binOpModifierTerms = [{ label: 'on' }, { label: 'ignoring' }, { label: 'group_left' }, { label: 'group_right' }];
-export const functionIdentifierTerms: AutoCompleteNode[] = [
+export const functionIdentifierTerms = [
   {
     label: 'abs',
+    detail: 'function',
     info: 'Return absolute values of input series',
   },
   {
     label: 'absent',
+    detail: 'function',
     info: 'Determine whether input vector is empty',
   },
   {
     label: 'absent_over_time',
+    detail: 'function',
     info: 'Determine whether input range vector is empty',
   },
   {
     label: 'avg_over_time',
+    detail: 'function',
     info: 'Average series values over time',
   },
   {
     label: 'ceil',
+    detail: 'function',
     info: 'Round up values of input series to nearest integer',
   },
   {
     label: 'changes',
+    detail: 'function',
     info: 'Return number of value changes in input series over time',
   },
   {
     label: 'clamp_max',
+    detail: 'function',
     info: 'Limit the value of input series to a maximum',
   },
   {
     label: 'clamp_min',
+    detail: 'function',
     info: 'Limit the value of input series to a minimum',
   },
   {
     label: 'count_over_time',
+    detail: 'function',
     info: 'Count the number of values for each input series',
   },
   {
     label: 'days_in_month',
+    detail: 'function',
     info: 'Return the number of days in current month for provided timestamps',
   },
   {
     label: 'day_of_month',
+    detail: 'function',
     info: 'Return the day of the month for provided timestamps',
   },
   {
     label: 'day_of_week',
+    detail: 'function',
     info: 'Return the day of the week for provided timestamps',
   },
   {
     label: 'delta',
+    detail: 'function',
     info: 'Calculate the difference between beginning and end of a range vector (for gauges)',
   },
   {
     label: 'deriv',
+    detail: 'function',
     info: 'Calculate the per-second derivative over series in a range vector (for gauges)',
   },
   {
     label: 'exp',
+    detail: 'function',
     info: 'Calculate exponential function for input vector values',
   },
   {
     label: 'floor',
+    detail: 'function',
     info: 'Round down values of input series to nearest integer',
   },
   {
     label: 'histogram_quantile',
+    detail: 'function',
     info: 'Calculate quantiles from histogram buckets',
   },
   {
     label: 'holt_winters',
+    detail: 'function',
     info: 'Calculate smoothed value of input series',
   },
   {
     label: 'hour',
+    detail: 'function',
     info: 'Return the hour of the day for provided timestamps',
   },
   {
     label: 'idelta',
+    detail: 'function',
     info: 'Calculate the difference between the last two samples of a range vector (for counters)',
   },
   {
     label: 'increase',
+    detail: 'function',
     info: 'Calculate the increase in value over a range of time (for counters)',
   },
   {
     label: 'irate',
+    detail: 'function',
     info: 'Calculate the per-second increase over the last two samples of a range vector (for counters)',
   },
   {
     label: 'label_replace',
+    detail: 'function',
     info: 'Set or replace label values',
   },
   {
     label: 'label_join',
+    detail: 'function',
     info: 'Join together label values into new label',
   },
   {
     label: 'ln',
+    detail: 'function',
     info: 'Calculate natural logarithm of input series',
   },
   {
     label: 'log10',
+    detail: 'function',
     info: 'Calulcate base-10 logarithm of input series',
   },
   {
     label: 'log2',
+    detail: 'function',
     info: 'Calculate base-2 logarithm of input series',
   },
   {
     label: 'max_over_time',
+    detail: 'function',
     info: 'Return the maximum value over time for input series',
   },
   {
     label: 'min_over_time',
+    detail: 'function',
     info: 'Return the minimum value over time for input series',
   },
   {
     label: 'minute',
+    detail: 'function',
     info: 'Return the minute of the hour for provided timestamps',
   },
   {
     label: 'month',
+    detail: 'function',
     info: 'Return the month for provided timestamps',
   },
   {
     label: 'predict_linear',
+    detail: 'function',
     info: 'Predict the value of a gauge into the future',
   },
   {
     label: 'quantile_over_time',
+    detail: 'function',
     info: 'Calculate value quantiles over time for input series',
   },
   {
     label: 'rate',
+    detail: 'function',
     info: 'Calculate per-second increase over a range vector (for counters)',
   },
   {
     label: 'resets',
+    detail: 'function',
     info: 'Return number of value decreases (resets) in input series of time',
   },
   {
     label: 'round',
+    detail: 'function',
     info: 'Round values of input series to nearest integer',
   },
   {
     label: 'scalar',
+    detail: 'function',
     info: 'Convert single-element series vector into scalar value',
   },
   {
     label: 'sort',
+    detail: 'function',
     info: 'Sort input series ascendingly by value',
   },
   {
     label: 'sort_desc',
+    detail: 'function',
     info: 'Sort input series descendingly by value',
   },
   {
     label: 'sqrt',
+    detail: 'function',
     info: 'Return the square root for input series',
   },
   {
     label: 'stddev_over_time',
+    detail: 'function',
     info: 'Calculate the standard deviation within input series over time',
   },
   {
     label: 'stdvar_over_time',
+    detail: 'function',
     info: 'Calculate the standard variation within input series over time',
   },
   {
     label: 'sum_over_time',
+    detail: 'function',
     info: 'Calculate the sum over the values of input series over time',
   },
   {
     label: 'time',
+    detail: 'function',
     info: 'Return the Unix timestamp at the current evaluation time',
   },
   {
     label: 'timestamp',
+    detail: 'function',
     info: 'Return the Unix timestamp for the samples in the input vector',
   },
   {
     label: 'vector',
+    detail: 'function',
     info: 'Convert a scalar value into a single-element series vector',
   },
   {
     label: 'year',
+    detail: 'function',
     info: 'Return the year for provided timestamps',
   },
 ];
-functionIdentifierTerms.forEach((term) => {
-  term.detail = 'function';
-});
-export const aggregateOpTerms: AutoCompleteNode[] = [
+export const aggregateOpTerms = [
   {
     label: 'avg',
+    detail: 'aggregation',
     info: 'Calculate the average over dimensions',
   },
   {
     label: 'bottomk',
+    detail: 'aggregation',
     info: 'Smallest k elements by sample value',
   },
   {
     label: 'count',
+    detail: 'aggregation',
     info: 'Count number of elements in the vector',
   },
   {
     label: 'count_values',
+    detail: 'aggregation',
     info: 'Count number of elements with the same value',
   },
   {
     label: 'group',
+    detail: 'aggregation',
     info: 'All values in the resulting vector are 1',
   },
   {
     label: 'max',
+    detail: 'aggregation',
     info: 'Select maximum over dimensions',
   },
   {
     label: 'min',
+    detail: 'aggregation',
     info: 'Select minimum over dimensions',
   },
   {
     label: 'quantile',
+    detail: 'aggregation',
     info: 'Calculate φ-quantile (0 ≤ φ ≤ 1) over dimensions',
   },
   {
     label: 'stddev',
+    detail: 'aggregation',
     info: 'Calculate population standard deviation over dimensions',
   },
   {
     label: 'stdvar',
+    detail: 'aggregation',
     info: 'Calculate population standard variance over dimensions',
   },
   {
     label: 'sum',
+    detail: 'aggregation',
     info: 'Calculate sum over dimensions',
   },
   {
     label: 'topk',
+    detail: 'aggregation',
     info: 'Largest k elements by sample value',
   },
 ];
-aggregateOpTerms.forEach((term) => {
-  term.detail = 'aggregation';
-});
 
 export const aggregateOpModifierTerms = [{ label: 'by' }, { label: 'without' }];


### PR DESCRIPTION
[As discussed](https://github.com/prometheus-community/codemirror-promql/pull/52#pullrequestreview-500252188), this PR adds help info for Prom's built-in aggregations and functions:

![Screenshot from 2020-10-02 13-38-12](https://user-images.githubusercontent.com/5953369/94894933-8c55f500-04b4-11eb-980b-7ccf18061059.png)

![Screenshot from 2020-10-02 13-37-59](https://user-images.githubusercontent.com/5953369/94894937-8d872200-04b4-11eb-9662-287fa70a27c6.png)

These description come from [Grafana's Prom plugin](https://github.com/grafana/grafana/blob/aae25c530873c0db51d987d1a1bfe84aeda0b3b1/public/app/plugins/datasource/prometheus/promql.ts#L16). Please feel free to suggest any change :D I think they are quite longer than @juliusv 's version.

Also [there is a bug](https://github.com/codemirror/codemirror.next/issues/302) in CodeMirror that the `max-width: 300px` of the Tooltip is not applied at all. I filed both issue and a PR to fix that in CMN repo.
