### PR TITLE
autocomplete duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://prometheus-community.github.io/codemirror-promql/
 
 Here is a short preview of it looks like currently:
 
-![final_highlight](https://user-images.githubusercontent.com/4548045/89693931-565f1f00-d910-11ea-8bcf-c8b37d6d3196.gif)
+![preview](https://user-images.githubusercontent.com/4548045/95660829-d5e4b680-0b2a-11eb-9ecb-41dca6396273.gif)
 
 ### RoadMap
 A roadmap is available in the issue [#5](https://github.com/prometheus-community/codemirror-promql/issues/5).

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -22,7 +22,7 @@
 
 import { basicSetup, EditorState, EditorView } from '@codemirror/next/basic-setup';
 import { PromQLExtension } from '../lang-promql';
-import { promQLHighlightMaterialTheme } from './theme';
+import { customTheme, promQLHighlightMaterialTheme } from './theme';
 
 const promqlExtension = new PromQLExtension();
 let editor: EditorView;
@@ -55,7 +55,7 @@ function createEditor() {
   }
   editor = new EditorView({
     state: EditorState.create({
-      extensions: [basicSetup, promqlExtension.asExtension(), promQLHighlightMaterialTheme],
+      extensions: [basicSetup, promqlExtension.asExtension(), promQLHighlightMaterialTheme, customTheme],
       doc: doc,
     }),
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -1,4 +1,5 @@
 import { highlighter } from '@codemirror/next/highlight';
+import { EditorView } from '@codemirror/next/basic-setup';
 
 // promQLHighlightMaterialTheme is based on the material theme defined here:
 // https://codemirror.net/theme/material.css
@@ -22,4 +23,17 @@ export const promQLHighlightMaterialTheme = highlighter({
   'propertyName definition': { color: '#00c' },
   comment: { color: '#546E7A' },
   meta: { color: '#FFCB6B' },
+});
+
+export const customTheme = EditorView.theme({
+  $completionDetail: {
+    marginLeft: '0.5em',
+    float: 'right',
+    color: '#9d4040',
+  },
+  $completionMatchedText: {
+    color: '#83080a',
+    textDecoration: 'none',
+    fontWeight: 'bold',
+  },
 });

--- a/src/lang-promql/complete/hybrid.test.ts
+++ b/src/lang-promql/complete/hybrid.test.ts
@@ -127,6 +127,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.LabelValue, metricName: 'metric_name', labelName: 'labelName' }],
     },
     {
+      title: 'autocomplete the labelValue associated to a labelName',
+      expr: '{labelName=""}',
+      pos: 12, // cursor is between the quotes
+      expectedContext: [{ kind: ContextKind.LabelValue, metricName: '', labelName: 'labelName' }],
+    },
+    {
       title: 'autocomplete aggregate operation modifier',
       expr: 'sum() b',
       pos: 7, // cursor is between the quotes

--- a/src/lang-promql/complete/hybrid.test.ts
+++ b/src/lang-promql/complete/hybrid.test.ts
@@ -198,6 +198,24 @@ describe('analyzeCompletion test', () => {
       pos: 16,
       expectedContext: [{ kind: ContextKind.BinOp }, { kind: ContextKind.Offset }],
     },
+    {
+      title: 'autocomplete duration for a matrixSelector',
+      expr: 'go[]',
+      pos: 3,
+      expectedContext: [{ kind: ContextKind.Duration }],
+    },
+    {
+      title: 'autocomplete duration for a matrixSelector 2',
+      expr: 'go[5]',
+      pos: 4,
+      expectedContext: [{ kind: ContextKind.Duration }],
+    },
+    {
+      title: 'autocomplete duration for a matrixSelector 3',
+      expr: 'rate(my_metric{l1="l2"}[25])',
+      pos: 26,
+      expectedContext: [{ kind: ContextKind.Duration }],
+    },
   ];
   testCases.forEach((value) => {
     it(value.title, () => {
@@ -312,6 +330,24 @@ describe('computeStartCompletePosition test', () => {
       expr: 'sum(http_requests_total{method="GET"} offset 4)',
       pos: 46,
       expectedStart: 46,
+    },
+    {
+      title: 'start should be equal to the pos for the duration in a matrix selector',
+      expr: 'go[]',
+      pos: 3,
+      expectedStart: 3,
+    },
+    {
+      title: 'start should be equal to the pos for the duration in a matrix selector 2',
+      expr: 'go[5]',
+      pos: 4,
+      expectedStart: 4,
+    },
+    {
+      title: 'start should be equal to the pos for the duration in a matrix selector 3',
+      expr: 'rate(my_metric{l1="l2"}[25])',
+      pos: 26,
+      expectedStart: 26,
     },
   ];
   testCases.forEach((value) => {

--- a/src/lang-promql/complete/hybrid.test.ts
+++ b/src/lang-promql/complete/hybrid.test.ts
@@ -211,6 +211,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [],
     },
     {
+      title: 'not autocompleting duration for a matrixSelector 2',
+      expr: 'go{l1="l2"}[]',
+      pos: 12,
+      expectedContext: [],
+    },
+    {
       title: 'autocomplete duration for a matrixSelector',
       expr: 'go[5]',
       pos: 4,
@@ -338,19 +344,19 @@ describe('computeStartCompletePosition test', () => {
       expectedStart: 46,
     },
     {
-      title: 'start should be equal to the pos for the duration in a matrix selector',
+      title: 'start should not be equal to the pos for the duration in a matrix selector',
       expr: 'go[]',
       pos: 3,
-      expectedStart: 3,
+      expectedStart: 0,
     },
     {
-      title: 'start should be equal to the pos for the duration in a matrix selector 2',
+      title: 'start should be equal to the pos for the duration in a matrix selector',
       expr: 'go[5]',
       pos: 4,
       expectedStart: 4,
     },
     {
-      title: 'start should be equal to the pos for the duration in a matrix selector 3',
+      title: 'start should be equal to the pos for the duration in a matrix selector 2',
       expr: 'rate(my_metric{l1="l2"}[25])',
       pos: 26,
       expectedStart: 26,

--- a/src/lang-promql/complete/hybrid.test.ts
+++ b/src/lang-promql/complete/hybrid.test.ts
@@ -205,19 +205,19 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.BinOp }, { kind: ContextKind.Offset }],
     },
     {
-      title: 'autocomplete duration for a matrixSelector',
+      title: 'not autocompleting duration for a matrixSelector',
       expr: 'go[]',
       pos: 3,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [],
     },
     {
-      title: 'autocomplete duration for a matrixSelector 2',
+      title: 'autocomplete duration for a matrixSelector',
       expr: 'go[5]',
       pos: 4,
       expectedContext: [{ kind: ContextKind.Duration }],
     },
     {
-      title: 'autocomplete duration for a matrixSelector 3',
+      title: 'autocomplete duration for a matrixSelector 2',
       expr: 'rate(my_metric{l1="l2"}[25])',
       pos: 26,
       expectedContext: [{ kind: ContextKind.Duration }],

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -46,6 +46,7 @@ import {
   Lss,
   Lte,
   MatchOp,
+  MatrixSelector,
   MetricIdentifier,
   Mod,
   Mul,
@@ -132,7 +133,7 @@ function getMetricNameInVectorSelector(tree: Subtree, state: EditorState): strin
   return state.sliceDoc(currentNode.start, currentNode.end);
 }
 
-function arrayToCompletionResult(data: AutoCompleteNodes[], from: number, to: number, includeSnippet = false): CompletionResult {
+function arrayToCompletionResult(data: AutoCompleteNodes[], from: number, to: number, includeSnippet = false, span = true): CompletionResult {
   const options: Completion[] = [];
 
   for (const completionList of data) {
@@ -152,7 +153,7 @@ function arrayToCompletionResult(data: AutoCompleteNodes[], from: number, to: nu
     from: from,
     to: to,
     options: options,
-    span: /^[a-zA-Z0-9_:]+$/,
+    span: span ? /^[a-zA-Z0-9_:]+$/ : undefined,
   } as CompletionResult;
 }
 
@@ -181,7 +182,11 @@ export function computeStartCompletePosition(node: Subtree, pos: number): number
     // if start would be `node.start`, then at the end it would try to autocomplete a string that starts with labelName! and not by !
     // `!` is contain in the error node so in the lastChild in this situation
     start = node.lastChild.start;
-  } else if (node.type.id === OffsetExpr || (node.type.id === 0 && node.parent?.type.id === OffsetExpr)) {
+  } else if (
+    node.type.id === OffsetExpr ||
+    (node.type.id === MatrixSelector && containsAtLeastOneChild(node, 0)) ||
+    (node.type.id === 0 && (node.parent?.type.id === OffsetExpr || node.parent?.type.id === MatrixSelector))
+  ) {
     start = pos;
   }
   return start;
@@ -199,6 +204,13 @@ export function analyzeCompletion(state: EditorState, node: Subtree): Context[] 
         // `metric_name offset 5` that leads to this tree:
         // `Expr(OffsetExpr(Expr(VectorSelector(MetricIdentifier(Identifier))),Offset,⚠))`
         // Here we can just autocomplete a duration.
+        result.push({ kind: ContextKind.Duration });
+        break;
+      }
+      if (node.parent?.type.id === MatrixSelector) {
+        // we are likely in the given situation:
+        // `metric_name{}[5]`
+        // We can also just autocomplete a duration
         result.push({ kind: ContextKind.Duration });
         break;
       }
@@ -346,6 +358,14 @@ export function analyzeCompletion(state: EditorState, node: Subtree): Context[] 
     case FunctionCallBody:
       result.push({ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation });
       break;
+    case MatrixSelector:
+      if (containsAtLeastOneChild(node, 0)) {
+        // we are likely in the given situation:
+        // `my_metric[]`
+        // we should autocomplete the duration.
+        result.push({ kind: ContextKind.Duration });
+      }
+      break;
     case Neq:
       if (node.parent?.type.id === MatchOp) {
         result.push({ kind: ContextKind.MatchOp });
@@ -392,8 +412,11 @@ export class HybridComplete implements CompleteStrategy {
     const { state, pos } = context;
     const tree = state.tree.resolve(pos, -1);
     const contexts = analyzeCompletion(state, tree);
+    console.log(`${state.tree.resolve(0, -1)}`);
+    console.log(`${tree.name}`)
     let asyncResult: Promise<AutoCompleteNodes[]> = Promise.resolve([]);
     let completeSnippet = false;
+    let span = true;
     for (const context of contexts) {
       switch (context.kind) {
         case ContextKind.Aggregation:
@@ -427,6 +450,7 @@ export class HybridComplete implements CompleteStrategy {
           });
           break;
         case ContextKind.Duration:
+          span = false;
           asyncResult = asyncResult.then((result) => {
             return result.concat(autocompleteNode.duration);
           });
@@ -454,7 +478,7 @@ export class HybridComplete implements CompleteStrategy {
       }
     }
     return asyncResult.then((result) => {
-      return arrayToCompletionResult(result, computeStartCompletePosition(tree, pos), pos, completeSnippet);
+      return arrayToCompletionResult(result, computeStartCompletePosition(tree, pos), pos, completeSnippet, span);
     });
   }
 

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -343,7 +343,7 @@ export function analyzeCompletion(state: EditorState, node: Subtree): Context[] 
         // Get the labelName.
         // By definition it's the firstChild: https://github.com/promlabs/lezer-promql/blob/0ef65e196a8db6a989ff3877d57fd0447d70e971/src/promql.grammar#L250
         let labelName = '';
-        if (node.parent.firstChild && node.parent.firstChild.type.id === LabelName) {
+        if (node.parent.firstChild?.type.id === LabelName) {
           labelName = state.sliceDoc(node.parent.firstChild.start, node.parent.firstChild.end);
         }
         // then find the metricName if it exists
@@ -412,8 +412,6 @@ export class HybridComplete implements CompleteStrategy {
     const { state, pos } = context;
     const tree = state.tree.resolve(pos, -1);
     const contexts = analyzeCompletion(state, tree);
-    console.log(`${state.tree.resolve(0, -1)}`);
-    console.log(`${tree.name}`)
     let asyncResult: Promise<AutoCompleteNodes[]> = Promise.resolve([]);
     let completeSnippet = false;
     let span = true;

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -184,7 +184,6 @@ export function computeStartCompletePosition(node: Subtree, pos: number): number
     start = node.lastChild.start;
   } else if (
     node.type.id === OffsetExpr ||
-    (node.type.id === MatrixSelector && containsAtLeastOneChild(node, 0)) ||
     (node.type.id === 0 && (node.parent?.type.id === OffsetExpr || node.parent?.type.id === MatrixSelector))
   ) {
     start = pos;

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -358,14 +358,6 @@ export function analyzeCompletion(state: EditorState, node: Subtree): Context[] 
     case FunctionCallBody:
       result.push({ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation });
       break;
-    case MatrixSelector:
-      if (containsAtLeastOneChild(node, 0)) {
-        // we are likely in the given situation:
-        // `my_metric[]`
-        // we should autocomplete the duration.
-        result.push({ kind: ContextKind.Duration });
-      }
-      break;
     case Neq:
       if (node.parent?.type.id === MatchOp) {
         result.push({ kind: ContextKind.MatchOp });


### PR DESCRIPTION
This PR adds the autocompletion of the duration for the MatrixSelector.

It's also adding a `filter` list in the context that is used for the moment to remove some labelValue already used in the vectorSelector.

That's what illustrate the gif below. It shows that when the user want to use again the label 'instance' there is no value autocompleted since it has been already used before.

![duration](https://user-images.githubusercontent.com/4548045/95660829-d5e4b680-0b2a-11eb-9ecb-41dca6396273.gif)

I also custom a bit the theme in the app just for the fun.