### PR TITLE
Improve walkThrough() node resolution by using end position

### DIFF
--- a/src/lang-promql/parser/parser.test.ts
+++ b/src/lang-promql/parser/parser.test.ts
@@ -115,6 +115,11 @@ describe('Scalars and scalar-to-scalar operations', () => {
       expectedDiag: [] as Diagnostic[],
     },
     {
+      expr: 'foo*bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
       expr: 'foo * sum',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
@@ -169,7 +174,17 @@ describe('Scalars and scalar-to-scalar operations', () => {
       expectedDiag: [] as Diagnostic[],
     },
     {
+      expr: 'foo*on(test,blub)bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
       expr: 'foo * on(test,blub) group_left bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo*on(test,blub)group_left()bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },

--- a/src/lang-promql/parser/parser.test.ts
+++ b/src/lang-promql/parser/parser.test.ts
@@ -120,6 +120,21 @@ describe('Scalars and scalar-to-scalar operations', () => {
       expectedDiag: [] as Diagnostic[],
     },
     {
+      expr: 'foo* bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo *bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo==bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
       expr: 'foo * sum',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],

--- a/src/lang-promql/parser/path-finder.ts
+++ b/src/lang-promql/parser/path-finder.ts
@@ -52,7 +52,7 @@ export function walkThrough(node: Subtree, ...path: (number | string)[]): Subtre
         if (i >= path.length) {
           // We reached the last node. We should return it then.
           // First get the first node resolved at the `start` position.
-          let result: Subtree | null = node.resolve(start, -1);
+          let result: Subtree | null = node.resolve(end, -1);
           if (result.type.id === type.id && result.start === start && result.end === end) {
             return result;
           }


### PR DESCRIPTION
This correctly finds the metric name "b" in "a+b", where previously it
did not.

Fixes https://github.com/prometheus-community/codemirror-promql/issues/69

Signed-off-by: Julius Volz <julius.volz@gmail.com>