### PR TITLE
Fix the way to retrieve the parameter in the function

### DIFF
--- a/src/lang-promql/parser/parser.ts
+++ b/src/lang-promql/parser/parser.ts
@@ -260,16 +260,16 @@ export class Parser {
 
     if (funcSignature.variadic === 0) {
       if (args.length !== nargs) {
-        this.addDiagnostic(node, `expected ${nargs} argument(s) in call to ${funcSignature.name}, got ${args.length}`);
+        this.addDiagnostic(node, `expected ${nargs} argument(s) in call to "${funcSignature.name}", got ${args.length}`);
       }
     } else {
       const na = nargs - 1;
       if (na > args.length) {
-        this.addDiagnostic(node, `expected at least ${na} argument(s) in call to ${funcSignature.name}, got ${args.length}`);
+        this.addDiagnostic(node, `expected at least ${na} argument(s) in call to "${funcSignature.name}", got ${args.length}`);
       } else {
         const nargsmax = na + funcSignature.variadic;
         if (funcSignature.variadic > 0 && nargsmax < args.length) {
-          this.addDiagnostic(node, `expected at most ${nargsmax} argument(s) in call to ${funcSignature.name}, got ${args.length}`);
+          this.addDiagnostic(node, `expected at most ${nargsmax} argument(s) in call to "${funcSignature.name}", got ${args.length}`);
         }
       }
     }
@@ -285,7 +285,7 @@ export class Parser {
         }
         j = funcSignature.argTypes.length - 1;
       }
-      this.expectType(args[i], funcSignature.argTypes[j], `call to function ${funcSignature.name}`);
+      this.expectType(args[i], funcSignature.argTypes[j], `call to function "${funcSignature.name}"`);
     }
   }
 

--- a/src/lang-promql/parser/path-finder.ts
+++ b/src/lang-promql/parser/path-finder.ts
@@ -123,7 +123,7 @@ export function retrieveAllRecursiveNodes(parentNode: Subtree | undefined | null
   const nodes: Subtree[] = [];
 
   function recursiveRetrieveNode(node: Subtree | undefined | null, nodes: Subtree[]) {
-    const subNode = node?.firstChild;
+    const subNode = node ? walkThrough(node, recursiveNode) : undefined;
     const le = node?.lastChild;
     if (subNode && subNode.type.id === recursiveNode) {
       recursiveRetrieveNode(subNode, nodes);


### PR DESCRIPTION
Before this PR, it was assuming that the recursive node was the firstChild. But as you can put a comment literally anywhere you would like, then the first child can be a comment.

So instead we just have to search where is the recursive node in the child (using the method `walkThrough` because that's the easiest way for the moment. It should be deeply reviewed when using the new lezer version (v0.12.0))

fix #78 

Note: I guess this problem should appear in the Binary operation as well and more generally everywhere the code is assuming that a node is at the first place in the child.