### PR TITLE
Moving to lezer v0.12.0 through codemirror.next v0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,22 +25,22 @@
       }
     },
     "@codemirror/next": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/next/-/next-0.13.1.tgz",
-      "integrity": "sha512-J/P0bxqkGwzhbnsqGT0mQFVWTtmKoJvMvAOv/DAlgcXDGfVU2seIF2s2ikZZ6Q6Ryb71MfMyE7nLMicT1oQeIQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/next/-/next-0.14.0.tgz",
+      "integrity": "sha512-DHveMIKsX3BK+5GY1IZcGz5+Kwj8wkghuefP8Fxd9vD48xRsuXtvsPBbx9e81QojVotRlDnZ0HzlwfXs449b+Q==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.0",
-        "lezer-cpp": "^0.11.0",
-        "lezer-css": "^0.11.0",
-        "lezer-html": "^0.11.0",
-        "lezer-java": "^0.11.0",
-        "lezer-javascript": "^0.11.0",
-        "lezer-json": "^0.11.0",
-        "lezer-python": "^0.11.0",
-        "lezer-rust": "^0.11.1",
-        "lezer-tree": "^0.11.0",
-        "lezer-xml": "^0.11.0",
+        "lezer": "^0.12.0",
+        "lezer-cpp": "^0.12.0",
+        "lezer-css": "^0.12.0",
+        "lezer-html": "^0.12.0",
+        "lezer-java": "^0.12.0",
+        "lezer-javascript": "^0.12.0",
+        "lezer-json": "^0.12.0",
+        "lezer-python": "^0.12.0",
+        "lezer-rust": "^0.12.0",
+        "lezer-tree": "^0.12.0",
+        "lezer-xml": "^0.12.0",
         "style-mod": "^3.0.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -4211,105 +4211,104 @@
       }
     },
     "lezer": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.11.2.tgz",
-      "integrity": "sha512-ktbo5G+sMY6qOXaeCbC4Z5Cs0vUTx5H4KkjnjTCi/LHay8taBp88dcUXjLS5XV7E/I3+y1zZGgIXhua82Z0Ljw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.12.0.tgz",
+      "integrity": "sha512-vkpuF9N+1uRAf67hVqE0h70/2xgawAoF+9mtJ8sq5v4GTNrulGdKPw/y38yrshp6wuUk/PeAkmUflyjk288q4w==",
+      "dev": true,
       "requires": {
-        "lezer-tree": "^0.11.0"
+        "lezer-tree": "^0.12.0"
       }
     },
     "lezer-cpp": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-cpp/-/lezer-cpp-0.11.1.tgz",
-      "integrity": "sha512-+hPUqZSJd+iUaxP2nNqZxMfGrwyRtGCsGLnxHJf0e9pjVxMQ96+nGDyKPArcAkT5n12OQwMi5g4IxidEpJ1JXw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-cpp/-/lezer-cpp-0.12.0.tgz",
+      "integrity": "sha512-/iPfD7jIBK70TpLYctpDW3mYPUzfiO3PZHCTsQ1XC3cPyNwkb77HuJF/8UE7c19cQ9ukkVMEedUVUSTL5TDJPQ==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-css": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-css/-/lezer-css-0.11.1.tgz",
-      "integrity": "sha512-uspAxtw56H200p1MKQyozY6vy/uooNBJP3zPhMuOjE+Q5qNgiLDAK9G6eW9/qGNLifRD2DhqTX0uAPiOaiXDtg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-css/-/lezer-css-0.12.0.tgz",
+      "integrity": "sha512-xKZtITo9cnN6Ba6qYWIy4a0X4qyv8paQ/NEfG3Qy6URfUCU8LnisO89uQmnMRqS1HbaddyvshWCPMWL9LjSf1A==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-html": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-html/-/lezer-html-0.11.1.tgz",
-      "integrity": "sha512-ub9oRgTrCQzgO3coLZlKbmODquIuR6VouBVzprxo17yeuhHbuq7c94pY7xQd6k+ied/dw7kMEROo6ekjDNtS6A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-html/-/lezer-html-0.12.0.tgz",
+      "integrity": "sha512-4bdJ03hHamnz6mNbpUKhb1mEqpAEuKwtgW3GZ4oE7CWedOoikbxmxi4utsU71quNftMeUlQXbgbLAaC8UYn2Mw==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-java": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-java/-/lezer-java-0.11.1.tgz",
-      "integrity": "sha512-g319H9R+gh/epYat2ajn67wbL72BuyrAJMNIh2qWnmwPHLPsFZNmYyUXuCcqqOuhrQwvc7HwN7ZXK03oCHH5DA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-java/-/lezer-java-0.12.0.tgz",
+      "integrity": "sha512-CMbMDx4N5kkTBi2fJdrBkeVM2DKml0fx27KOmfBbfYCO75MmlsAyRZvVN06MKfnZIAu7xQvcZKW79qZb+vFjhw==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-javascript": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-javascript/-/lezer-javascript-0.11.1.tgz",
-      "integrity": "sha512-XAlZe8BirVBPB7SHTg975W4HQfuV/ZRgqVry+iklCqVR9cqRZYQMd98EHpf/j0J1NyvOFw6FJL3kPrq1Zglidw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-javascript/-/lezer-javascript-0.12.0.tgz",
+      "integrity": "sha512-MDtpghjTXEUO3HOuBGIv8msszI5WBjQzs8EOSb1fXBpWDIywxmxAT0y4FdPckWLny8gANOSppZOqJcPJ9Img8g==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-json": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-json/-/lezer-json-0.11.1.tgz",
-      "integrity": "sha512-ziT9OzwqlLskEIAVBVxq25tJEhDphOKoYk42cfZfzlm8sL12jBugHdkEVuO9BiVfGIh1aj1wJYFxpP9UMf8WKw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-json/-/lezer-json-0.12.0.tgz",
+      "integrity": "sha512-rqGyuut/uxiySn6uXpwQKaU2PLB/YSyWLxdYvujV58QM9lH9D2Jqcl2ZTkH0AMYlDuGpJ6w2oQfJevqp2U3Mhw==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-promql": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/lezer-promql/-/lezer-promql-0.12.0.tgz",
-      "integrity": "sha512-9aOvppW4nY5nYV+uz/jfTyehK12VzaLmRVEkGQWaxzTOgIRg7Krn6psMcXF7uoL71cLOdFijTafEFSkJROKMBQ==",
-      "requires": {
-        "lezer": "^0.11.1"
-      }
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/lezer-promql/-/lezer-promql-0.13.0.tgz",
+      "integrity": "sha512-3GfALjYLQy+gpuHMsIgJ7Rk1NaBZ6Llo42BnPuUdplMpFxLhSoQmv9+2qyPtHnwc4yKz0NBRtSU9mhajQjCp3Q=="
     },
     "lezer-python": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-python/-/lezer-python-0.11.1.tgz",
-      "integrity": "sha512-cfopeLETQiKzBmjsENUmz0a8jCIqQkAeCeakypdX3lvMffEK6EIi0y8S8+Zb4TQbdwuzz3jB9nd8dmof1LGPxw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-python/-/lezer-python-0.12.0.tgz",
+      "integrity": "sha512-eLUWCXMfmQG0ssiVIp2JTr2WUPB0VpIDSj4st1j50hkpBeZA/o2BPU2IBS8C09EXfHG1wyz5pZBnN4r5RpdP+w==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-rust": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-rust/-/lezer-rust-0.11.1.tgz",
-      "integrity": "sha512-Nac9eu9HSuop854qhE2EKPye7qbUtIlQTwWMwwm6hL60Mm6xwzwvaLxnQkQljl2OyQQ6xMoBTUemLIGMFztdCw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-rust/-/lezer-rust-0.12.0.tgz",
+      "integrity": "sha512-BS/x06WiAEZbgpTeg9aDVVvQAjJxkqKG2odyIoP6v9g5MwPWRkCbzgaupXubYDtiJVZMp3/i8Ne/cV8DzJivsw==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.0"
+        "lezer": "^0.12.0"
       }
     },
     "lezer-tree": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.11.1.tgz",
-      "integrity": "sha512-AC1FmSzxL/cxV8LrbPMW6+8P/CaG8AxRql1XjzIfLkTQHY3LUan6tG8aieB/OvZmz0NuQpgfw6yDegXFNzVK4A=="
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.12.3.tgz",
+      "integrity": "sha512-3WPuomiOpnivc+DrXdZj1C+gImdSgCYeiwkqFgbWenRv1/zgP3QO5Eij5rDwS7R2rDI7hozVNrg/Yy4tkOhF9A==",
+      "dev": true
     },
     "lezer-xml": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/lezer-xml/-/lezer-xml-0.11.1.tgz",
-      "integrity": "sha512-FoJX8xvF80zunwWGYyPsDSmEJTKuOvipIQ5BSrn7tBaC6LTEvZ/q9mkew/3/dqpjdQfDhW8DCSoDvb/rFvqdnA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lezer-xml/-/lezer-xml-0.12.0.tgz",
+      "integrity": "sha512-UrxplFVl7QT9MOxkdfPGgeAuYg84XoZ8U/WSiNLOHU7ZCKP+ov8vlYuEI5DxaFHJqu9zbIO+CRzdEGPinWsAXg==",
       "dev": true,
       "requires": {
-        "lezer": "^0.11.1"
+        "lezer": "^0.12.0"
       }
     },
     "load-json-file": {
@@ -7108,9 +7107,9 @@
       "dev": true
     },
     "style-mod": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-3.0.1.tgz",
-      "integrity": "sha512-bsenHWrMniPiF9eGM3e9Gzw1AF0Bkae6liAB11U1TaNVSbZMSpfazzJy+1liMynoHi6RTwTeINr5QevPKrovkg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-3.1.0.tgz",
+      "integrity": "sha512-0N9E+FSiBMBgwek1njE4Vt2WMmWZReTrKfCY6xUCXuHLJcjXxJrPG504dH2oufQHhEZp0aZs3v/uVHRz5LepTA==",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   },
   "homepage": "https://github.com/prometheus-community/codemirror-promql/blob/master/README.md",
   "dependencies": {
-    "lezer-promql": "^0.12.0"
+    "lezer-promql": "^0.13.0"
   },
   "devDependencies": {
-    "@codemirror/next": "^0.13.1",
+    "@codemirror/next": "^0.14.0",
     "@types/chai": "^4.2.12",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.0.13",

--- a/src/lang-promql/parser/parser.test.ts
+++ b/src/lang-promql/parser/parser.test.ts
@@ -728,7 +728,7 @@ describe('promql operations', () => {
     const state = createEditorState(value.expr);
     const parser = new Parser(state);
     it(value.expr, () => {
-      chai.expect(parser.checkAST(state.tree.firstChild)).to.equal(value.expectedValueType);
+      chai.expect(parser.checkAST(state.tree.topNode.firstChild)).to.equal(value.expectedValueType);
       chai.expect(parser.getDiagnostics()).to.deep.equal(value.expectedDiag);
     });
   });

--- a/src/lang-promql/parser/parser.test.ts
+++ b/src/lang-promql/parser/parser.test.ts
@@ -27,7 +27,7 @@ import { Diagnostic } from '@codemirror/next/lint';
 import { createEditorState } from '../../test/utils';
 
 describe('promql operations', () => {
-  const testSuites = [
+  const testCases = [
     {
       expr: '1',
       expectedValueType: ValueType.scalar,
@@ -724,7 +724,7 @@ describe('promql operations', () => {
       expectedDiag: [],
     },
   ];
-  testSuites.forEach((value) => {
+  testCases.forEach((value) => {
     const state = createEditorState(value.expr);
     const parser = new Parser(state);
     it(value.expr, () => {

--- a/src/lang-promql/parser/parser.ts
+++ b/src/lang-promql/parser/parser.ts
@@ -90,6 +90,9 @@ export class Parser {
   private diagnoseAllErrorNodes() {
     const cursor = this.tree.cursor();
     while (cursor.next()) {
+      // usually there is an error node at the end of the expression when user is typing
+      // so it's not really a useful information to say the expression is wrong.
+      // Hopefully if there is an error node at the end of the tree, checkAST should yell more precisely
       if (cursor.type.id === 0 && cursor.to !== this.tree.topNode.to) {
         const node = cursor.node.parent;
         this.diagnostics.push({
@@ -103,8 +106,8 @@ export class Parser {
   }
 
   // checkAST is inspired of the same named method from prometheus/prometheus:
-  // https://github.com/prometheus/prometheus/blob/master/promql/parser/parse.go#L433
-  checkAST(node: SyntaxNode | undefined | null): ValueType {
+  // https://github.com/prometheus/prometheus/blob/3470ee1fbf9d424784eb2613bab5ab0f14b4d222/promql/parser/parse.go#L433
+  checkAST(node: SyntaxNode | null): ValueType {
     if (!node) {
       return ValueType.none;
     }

--- a/src/lang-promql/parser/parser.ts
+++ b/src/lang-promql/parser/parser.ts
@@ -91,11 +91,12 @@ export class Parser {
     const cursor = this.tree.cursor();
     while (cursor.next()) {
       if (cursor.type.id === 0 && cursor.to !== this.tree.topNode.to) {
+        const node = cursor.node.parent;
         this.diagnostics.push({
           severity: 'error',
           message: 'unexpected expression',
-          from: cursor.from,
-          to: cursor.to,
+          from: node ? node.from : cursor.from,
+          to: node ? node.to : cursor.to,
         });
       }
     }

--- a/src/lang-promql/parser/path-finder.test.ts
+++ b/src/lang-promql/parser/path-finder.test.ts
@@ -40,13 +40,20 @@ import {
   Neq,
   NumberLiteral,
   Sub,
+  VectorSelector,
 } from 'lezer-promql';
 import { createEditorState } from '../../test/utils';
-import { containsAtLeastOneChild, containsChild, retrieveAllRecursiveNodes, walkThrough } from './path-finder';
+import {
+  containsAtLeastOneChild,
+  containsChild,
+  retrieveAllRecursiveNodes,
+  walkBackward,
+  walkThrough
+} from './path-finder';
 import { SyntaxNode } from 'lezer-tree';
 
 describe('walkThrough test', () => {
-  const testSuites = [
+  const testCases = [
     {
       title: 'should return the node when no path is given',
       expr: '1 > bool 2',
@@ -87,7 +94,7 @@ describe('walkThrough test', () => {
       expectedDoc: '2',
     },
   ];
-  testSuites.forEach((value) => {
+  testCases.forEach((value) => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const subTree = state.tree.resolve(value.pos, -1);
@@ -105,7 +112,7 @@ describe('walkThrough test', () => {
 });
 
 describe('containsAtLeastOneChild test', () => {
-  const testSuites = [
+  const testCases = [
     {
       title: 'should not find a node if none is defined',
       expr: '1 > 2',
@@ -131,7 +138,7 @@ describe('containsAtLeastOneChild test', () => {
       expectedResult: false,
     },
   ];
-  testSuites.forEach((value) => {
+  testCases.forEach((value) => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const subTree = state.tree.resolve(value.pos, -1);
@@ -145,7 +152,7 @@ describe('containsAtLeastOneChild test', () => {
 });
 
 describe('containsChild test', () => {
-  const testSuites = [
+  const testCases = [
     {
       title: 'Should find all expr in a subtree',
       expr: 'metric_name / ignor',
@@ -171,7 +178,7 @@ describe('containsChild test', () => {
       child: [Expr, Expr],
     },
   ];
-  testSuites.forEach((value) => {
+  testCases.forEach((value) => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const subTree = state.tree.resolve(value.pos, -1);
@@ -193,5 +200,24 @@ describe('retrieveAllRecursiveNodes test', () => {
     if (tree) {
       chai.expect(3).to.equal(retrieveAllRecursiveNodes(walkThrough(tree, FunctionCall, FunctionCallBody), FunctionCallArgs, Expr).length);
     }
+  });
+});
+
+describe('walkbackward test', () => {
+  const testCases = [
+    {
+      title: 'should find the parent',
+      expr: 'metric_name{}',
+      pos: 12,
+      exit: VectorSelector,
+      expectedResult: VectorSelector,
+    },
+  ];
+  testCases.forEach((value) => {
+    it(value.title, () => {
+      const state = createEditorState(value.expr);
+      const tree = state.tree.resolve(value.pos, -1);
+      chai.expect(value.expectedResult).to.equal(walkBackward(tree, value.exit)?.type.id);
+    });
   });
 });

--- a/src/lang-promql/parser/path-finder.test.ts
+++ b/src/lang-promql/parser/path-finder.test.ts
@@ -43,7 +43,7 @@ import {
 } from 'lezer-promql';
 import { createEditorState } from '../../test/utils';
 import { containsAtLeastOneChild, containsChild, retrieveAllRecursiveNodes, walkThrough } from './path-finder';
-import { Subtree } from 'lezer-tree';
+import { SyntaxNode } from 'lezer-tree';
 
 describe('walkThrough test', () => {
   const testSuites = [
@@ -51,7 +51,7 @@ describe('walkThrough test', () => {
       title: 'should return the node when no path is given',
       expr: '1 > bool 2',
       pos: 0,
-      expectedNode: Expr,
+      expectedNode: 'PromQL',
       path: [] as number[],
       expectedDoc: '1 > bool 2',
     },
@@ -82,7 +82,7 @@ describe('walkThrough test', () => {
       title: 'should find a node in a recursive node definition',
       expr: 'rate(1, 2, 3)',
       pos: 0,
-      path: [FunctionCall, FunctionCallBody, FunctionCallArgs, FunctionCallArgs, Expr, NumberLiteral],
+      path: [Expr, FunctionCall, FunctionCallBody, FunctionCallArgs, FunctionCallArgs, Expr, NumberLiteral],
       expectedNode: NumberLiteral,
       expectedDoc: '2',
     },
@@ -91,11 +91,14 @@ describe('walkThrough test', () => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const subTree = state.tree.resolve(value.pos, -1);
-      const tree = subTree.name === '' && subTree.firstChild ? subTree.firstChild : subTree;
-      const node = walkThrough(tree, ...value.path);
-      chai.expect(value.expectedNode).to.equal(node?.type.id);
+      const node = walkThrough(subTree, ...value.path);
+      if (typeof value.expectedNode === 'number') {
+        chai.expect(value.expectedNode).to.equal(node?.type.id);
+      } else {
+        chai.expect(value.expectedNode).to.equal(node?.type.name);
+      }
       if (node) {
-        chai.expect(value.expectedDoc).to.equal(state.sliceDoc(node.start, node.end));
+        chai.expect(value.expectedDoc).to.equal(state.sliceDoc(node.from, node.to));
       }
     });
   });
@@ -115,7 +118,7 @@ describe('containsAtLeastOneChild test', () => {
       title: 'should find a node in the given list',
       expr: '1 > 2',
       pos: 0,
-      walkThrough: [BinaryExpr],
+      walkThrough: [Expr, BinaryExpr],
       child: [Eql, Neq, Lte, Lss, Gte, Gtr],
       expectedResult: true,
     },
@@ -123,7 +126,7 @@ describe('containsAtLeastOneChild test', () => {
       title: 'should not find a node in the given list',
       expr: '1 > 2',
       pos: 0,
-      walkThrough: [BinaryExpr],
+      walkThrough: [Expr, BinaryExpr],
       child: [Mul, Div, Mod, Add, Sub],
       expectedResult: false,
     },
@@ -132,10 +135,8 @@ describe('containsAtLeastOneChild test', () => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const subTree = state.tree.resolve(value.pos, -1);
-      const tree = subTree.name === '' && subTree.firstChild ? subTree.firstChild : subTree;
-      const node = walkThrough(tree, ...value.walkThrough);
+      const node = walkThrough(subTree, ...value.walkThrough);
       chai.expect(node).to.not.null;
-      chai.expect(node).to.not.undefined;
       if (node) {
         chai.expect(value.expectedResult).to.equal(containsAtLeastOneChild(node, ...value.child));
       }
@@ -150,15 +151,15 @@ describe('containsChild test', () => {
       expr: 'metric_name / ignor',
       pos: 0,
       expectedResult: true,
-      walkThrough: [BinaryExpr],
+      walkThrough: [Expr, BinaryExpr],
       child: [Expr, Expr],
     },
     {
-      title: 'Should find all expr at the root',
+      title: 'Should find all expr in a subtree 2',
       expr: 'http_requests_total{method="GET"} off',
       pos: 0,
       expectedResult: true,
-      walkThrough: [],
+      walkThrough: [Expr, BinaryExpr],
       child: [Expr, Expr],
     },
     {
@@ -166,7 +167,7 @@ describe('containsChild test', () => {
       expr: 'sum(ra)',
       pos: 0,
       expectedResult: false,
-      walkThrough: [AggregateExpr, FunctionCallBody, FunctionCallArgs],
+      walkThrough: [Expr, AggregateExpr, FunctionCallBody, FunctionCallArgs],
       child: [Expr, Expr],
     },
   ];
@@ -174,14 +175,9 @@ describe('containsChild test', () => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const subTree = state.tree.resolve(value.pos, -1);
-      let tree: Subtree = subTree;
-      let node: null | undefined | Subtree = subTree;
-      if (value.walkThrough.length > 0 || value.pos !== 0) {
-        tree = subTree.name === '' && subTree.firstChild ? subTree.firstChild : subTree;
-        node = walkThrough(tree, ...value.walkThrough);
-      }
+      const node: SyntaxNode | null = walkThrough(subTree, ...value.walkThrough);
+
       chai.expect(node).to.not.null;
-      chai.expect(node).to.not.undefined;
       if (node) {
         chai.expect(value.expectedResult).to.equal(containsChild(node, ...value.child));
       }
@@ -192,7 +188,7 @@ describe('containsChild test', () => {
 describe('retrieveAllRecursiveNodes test', () => {
   it('should find every occurrence', () => {
     const state = createEditorState('rate(1,2,3)');
-    const tree = state.tree.firstChild;
+    const tree = state.tree.topNode.firstChild;
     chai.expect(tree).to.not.null;
     if (tree) {
       chai.expect(3).to.equal(retrieveAllRecursiveNodes(walkThrough(tree, FunctionCall, FunctionCallBody), FunctionCallArgs, Expr).length);

--- a/src/lang-promql/parser/path-finder.test.ts
+++ b/src/lang-promql/parser/path-finder.test.ts
@@ -43,13 +43,7 @@ import {
   VectorSelector,
 } from 'lezer-promql';
 import { createEditorState } from '../../test/utils';
-import {
-  containsAtLeastOneChild,
-  containsChild,
-  retrieveAllRecursiveNodes,
-  walkBackward,
-  walkThrough
-} from './path-finder';
+import { containsAtLeastOneChild, containsChild, retrieveAllRecursiveNodes, walkBackward, walkThrough } from './path-finder';
 import { SyntaxNode } from 'lezer-tree';
 
 describe('walkThrough test', () => {

--- a/src/lang-promql/parser/path-finder.ts
+++ b/src/lang-promql/parser/path-finder.ts
@@ -28,7 +28,7 @@ export function walkBackward(node: SyntaxNode, exit: number): SyntaxNode | null 
   const cursor = node.cursor;
   let cursorIsMoving = true;
   while (cursorIsMoving && cursor.type.id !== exit) {
-    cursorIsMoving = cursor.prev();
+    cursorIsMoving = cursor.parent();
   }
   return cursor.type.id === exit ? cursor.node : null;
 }

--- a/src/lang-promql/parser/type.test.ts
+++ b/src/lang-promql/parser/type.test.ts
@@ -20,10 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { buildVectorMatching, ValueType, VectorMatchCardinality } from './type';
+import { buildVectorMatching, VectorMatchCardinality } from './type';
 import { createEditorState } from '../../test/utils';
 import { walkThrough } from './path-finder';
-import { BinaryExpr } from 'lezer-promql';
+import { BinaryExpr, Expr } from 'lezer-promql';
 import chai from 'chai';
 
 describe('buildVectorMatching test', () => {
@@ -209,7 +209,7 @@ describe('buildVectorMatching test', () => {
   testCases.forEach((value) => {
     it(value.binaryExpr, () => {
       const state = createEditorState(value.binaryExpr);
-      const node = walkThrough(state.tree.firstChild ? state.tree.firstChild : state.tree, BinaryExpr);
+      const node = walkThrough(state.tree.topNode, Expr, BinaryExpr);
       chai.expect(node).to.not.null;
       chai.expect(node).to.not.undefined;
       if (node) {

--- a/src/lang-promql/parser/type.ts
+++ b/src/lang-promql/parser/type.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Subtree } from 'lezer-tree';
+import { SyntaxNode } from 'lezer-tree';
 import {
   Abs,
   Absent,
@@ -406,7 +406,7 @@ export function getFunction(id: number): PromQLFunction {
 }
 
 // Based on https://github.com/prometheus/prometheus/blob/d668a7efe3107dbdcc67bf4e9f12430ed8e2b396/promql/parser/ast.go#L191
-export function getType(node: Subtree | null | undefined): ValueType {
+export function getType(node: SyntaxNode | null): ValueType {
   if (!node) {
     return ValueType.none;
   }
@@ -470,7 +470,7 @@ export interface VectorMatching {
   include: string[];
 }
 
-export function buildVectorMatching(state: EditorState, binaryNode: Subtree) {
+export function buildVectorMatching(state: EditorState, binaryNode: SyntaxNode) {
   if (!binaryNode || binaryNode.type.id !== BinaryExpr) {
     return null;
   }
@@ -491,7 +491,7 @@ export function buildVectorMatching(state: EditorState, binaryNode: Subtree) {
     );
     if (labels.length > 0) {
       for (const label of labels) {
-        result.matchingLabels.push(state.sliceDoc(label.start, label.end));
+        result.matchingLabels.push(state.sliceDoc(label.from, label.to));
       }
     }
   }
@@ -507,7 +507,7 @@ export function buildVectorMatching(state: EditorState, binaryNode: Subtree) {
     );
     if (includeLabels.length > 0) {
       for (const label of includeLabels) {
-        result.include.push(state.sliceDoc(label.start, label.end));
+        result.include.push(state.sliceDoc(label.from, label.to));
       }
     }
   }


### PR DESCRIPTION
This is a deep review of how we should iterate over the tree.

Note: as a side effect, it looks like the resolution of the tree is much more accurate and make more sense according to different weird case we had to patch with ugly code. ( like the autocompletion of the `MatchOp` )

And this is really cool we have many tests. Otherwise it would have been really hard to find what was broken after making this move.