### PR TITLE
Add a way to customize the completion result

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,47 @@ In case you would like to deactivate the linter and/or the autocompletion it's s
 const promQL = new PromQLExtension().activateLinter(false).activateCompletion(false) // here the linter and the autocomplete are deactivated
 ```
 
+### maxMetricsMetadata
+
+maxMetricsMetadata is the maximum limit of the number of metrics in Prometheus. Under this limit, it allows the completion to get the metadata of the metrics.
+
+By default, the limit is 10 000 metrics. 
+
+Use it cautiously. A high value of this limit can cause a crash of your browser due to too many data fetched.
+
+```typescript
+const promQL = new PromQLExtension().setComplete({maxMetricsMetadata: 10000})
+```
+
+### enricher
+
+enricher is a function that will allow user to enrich the current completion by adding a custom one. It takes two parameters:
+
+* `trigger` should be used to decide whenever you would like to trigger your custom completion.
+  It's better to not trigger the same completion for multiple different ContextKind.
+  For example, the autocompletion of the metricName / the function / the aggregation happens at the same time.
+  So if you want to trigger your custom completion for metricName / function / aggregation, you should just choose to trigger it for the function for example.
+  Otherwise, you will end up to have the same completion result multiple time.
+
+* `result` is the current result of the completion. Usually you don't want to override it but instead to concat your own completion with this one.
+
+```typescript
+import { Completion } from '@codemirror/next/autocomplete';
+import { ContextKind } from 'codemirror-promql';
+
+function myCustomEnricher(trigger: ContextKind, result: Completion[]): Completion[] | Promise<Completion[]> {
+  switch (trigger) {
+      case ContextKind.Aggregation:
+        // custom completion
+        // ...
+        // return result.concat( myCustomCompletionArray )
+      default:
+        return result;
+    }
+}
+const promQL = new PromQLExtension().setComplete({enricher: myCustomEnricher})
+```
+
 ### Connect the autocompletion extension to a remote Prometheus server
 Connecting the autocompletion extension to a remote Prometheus server will provide autocompletion of metric names, label names, and label values.
 
@@ -72,21 +113,21 @@ Connecting the autocompletion extension to a remote Prometheus server will provi
 If you want to use the default Prometheus client provided by this lib, you have to provide the url used to contact the Prometheus server.
 
 ```typescript
-const promQL = new PromQLExtension().setComplete({url: 'https://prometheus.land'})
+const promQL = new PromQLExtension().setComplete({remote: {url: 'https://prometheus.land'}})
 ```
 
 ##### Override FetchFn
 In case your Prometheus server is protected and requires a special HTTP client, you can override the function `fetchFn` that is used to perform any required HTTP request.
 
 ```typescript
-const promQL = new PromQLExtension().setComplete({fetchFn: myHTTPClient})
+const promQL = new PromQLExtension().setComplete({remote: {fetchFn: myHTTPClient}})
 ```
 
 ##### Error Handling
 You can set up your own error handler to catch any HTTP error that can occur when the PrometheusClient is contacting Prometheus.
 
 ```typescript
-const promQL = new PromQLExtension().setComplete({httpErrorHandler: (error:any) => console.error(error)})
+const promQL = new PromQLExtension().setComplete({remote: {httpErrorHandler: (error:any) => console.error(error)}})
 ```
 
 #### Override the default Prometheus client
@@ -94,7 +135,7 @@ In case you are not satisfied by our default Prometheus client, you can still pr
 It has to implement the interface [PrometheusClient](https://github.com/prometheus-community/codemirror-promql/blob/master/src/lang-promql/client/prometheus.ts#L111-L117).
 
 ```typescript
-const promQL = new PromQLExtension().setComplete({prometheusClient: MyPrometheusClient})
+const promQL = new PromQLExtension().setComplete({remote: {prometheusClient: MyPrometheusClient}})
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ const promQL = new PromQLExtension().activateLinter(false).activateCompletion(fa
 
 ### maxMetricsMetadata
 
-maxMetricsMetadata is the maximum limit of the number of metrics in Prometheus. Under this limit, it allows the completion to get the metadata of the metrics.
+`maxMetricsMetadata` is the maximum number of metrics in Prometheus for which metadata is fetched. 
+If the number of metrics exceeds this limit, no metric metadata is fetched at all.
 
 By default, the limit is 10 000 metrics. 
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -36,7 +36,9 @@ function setCompletion() {
       break;
     case 'prometheus':
       promqlExtension.setComplete({
-        url: 'http://localhost:9090',
+        remote: {
+          url: 'http://localhost:9090',
+        },
       });
       break;
     default:

--- a/src/lang-promql/client/index.ts
+++ b/src/lang-promql/client/index.ts
@@ -20,6 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-export { PrometheusClient } from './prometheus';
+export { PrometheusClient, PrometheusConfig } from './prometheus';
 
 export type FetchFn = (input: RequestInfo, init?: RequestInit) => Promise<Response>;

--- a/src/lang-promql/client/prometheus.ts
+++ b/src/lang-promql/client/prometheus.ts
@@ -53,6 +53,19 @@ export interface PrometheusClient {
   metricNames(prefix?: string): Promise<string[]>;
 }
 
+export interface PrometheusConfig {
+  url: string;
+  lookbackInterval?: number;
+  httpErrorHandler?: (error: any) => void;
+  fetchFn?: FetchFn;
+  // cache will allow user to change the configuration of the cached Prometheus client (which is used by default)
+  cache?: {
+    // maxAge is the maximum amount of time that a cached completion item is valid before it needs to be refreshed.
+    // It is in milliseconds. Default value:  300 000 (5min)
+    maxAge: number;
+  };
+}
+
 interface APIResponse<T> {
   status: 'success' | 'error';
   data?: T;
@@ -75,14 +88,14 @@ export class HTTPPrometheusClient implements PrometheusClient {
   // when calling it, thus the indirection via another function wrapper.
   private readonly fetchFn: FetchFn = (input: RequestInfo, init?: RequestInit): Promise<Response> => fetch(input, init);
 
-  constructor(url: string, errorHandler?: (error: any) => void, lookbackInterval?: number, fetchFn?: FetchFn) {
-    this.url = url;
-    this.errorHandler = errorHandler;
-    if (lookbackInterval) {
-      this.lookbackInterval = lookbackInterval;
+  constructor(config: PrometheusConfig) {
+    this.url = config.url;
+    this.errorHandler = config.httpErrorHandler;
+    if (config.lookbackInterval) {
+      this.lookbackInterval = config.lookbackInterval;
     }
-    if (fetchFn) {
-      this.fetchFn = fetchFn;
+    if (config.fetchFn) {
+      this.fetchFn = config.fetchFn;
     }
   }
 

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -111,7 +111,7 @@ export interface Context {
   matchers?: Matcher[];
 }
 
-// EnrichCompletionHandler define a function that will be called during the completion calculation.
+// EnrichCompletionHandler defines a function that will be called during the completion calculation.
 // * `trigger` should be used to decide whenever you would like to trigger your custom completion.
 //   It's better to not trigger the same completion for multiple different ContextKind.
 //   For example, the autocompletion of the metricName / the function / the aggregation happens at the same time.

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -111,6 +111,30 @@ export interface Context {
   matchers?: Matcher[];
 }
 
+// EnrichCompletionHandler define a function that will be called during the completion calculation.
+// * `trigger` should be used to decide whenever you would like to trigger your custom completion.
+//   It's better to not trigger the same completion for multiple different ContextKind.
+//   For example, the autocompletion of the metricName / the function / the aggregation happens at the same time.
+//   So if you want to trigger your custom completion for metricName / function / aggregation, you should just choose to trigger it for the function for example.
+//   Otherwise, you will end up to have the same completion result multiple time.
+// * result is the current result of the completion. Usually you don't want to override it but instead to concat your own completion with this one.
+// Typical implementation snippet:
+//     function myCustomEnricher(trigger: ContextKind, result: Completion[]): Completion[] | Promise<Completion[]> {
+//       switch (trigger) {
+//         case ContextKind.Aggregation:
+//           // custom completion
+//           // ...
+//           // return result.concat( myCustomCompletionArray )
+//         default:
+//           return result;
+//       }
+//     }
+export type EnrichCompletionHandler = (trigger: ContextKind, result: Completion[]) => Completion[] | Promise<Completion[]>;
+
+function defaultEnricher(trigger: ContextKind, result: Completion[]): Completion[] | Promise<Completion[]> {
+  return result;
+}
+
 function getMetricNameInVectorSelector(tree: SyntaxNode, state: EditorState): string {
   // Find if there is a defined metric name. Should be used to autocomplete a labelValue or a labelName
   // First find the parent "VectorSelector" to be able to find then the subChild "MetricIdentifier" if it exists.
@@ -376,10 +400,12 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
 export class HybridComplete implements CompleteStrategy {
   private readonly prometheusClient: PrometheusClient | undefined;
   private readonly maxMetricsMetadata: number;
+  private readonly enricher: EnrichCompletionHandler;
 
-  constructor(prometheusClient?: PrometheusClient, maxMetricsMetadata = 10000) {
+  constructor(prometheusClient?: PrometheusClient, maxMetricsMetadata = 10000, enricher = defaultEnricher) {
     this.prometheusClient = prometheusClient;
     this.maxMetricsMetadata = maxMetricsMetadata;
+    this.enricher = enricher;
   }
 
   promQL(context: CompletionContext): Promise<CompletionResult> | CompletionResult | null {
@@ -448,13 +474,16 @@ export class HybridComplete implements CompleteStrategy {
             return this.autocompleteLabelValue(result, context);
           });
       }
+      asyncResult = asyncResult.then((result) => {
+        return this.enricher(context.kind, result);
+      });
     }
     return asyncResult.then((result) => {
       return arrayToCompletionResult(result, computeStartCompletePosition(tree, pos), pos, completeSnippet, span);
     });
   }
 
-  private autocompleteMetricName(result: Completion[], context: Context) {
+  private autocompleteMetricName(result: Completion[], context: Context): Completion[] | Promise<Completion[]> {
     if (!this.prometheusClient) {
       return result;
     }
@@ -522,7 +551,7 @@ export class HybridComplete implements CompleteStrategy {
       });
   }
 
-  private autocompleteLabelName(result: Completion[], context: Context) {
+  private autocompleteLabelName(result: Completion[], context: Context): Completion[] | Promise<Completion[]> {
     if (!this.prometheusClient) {
       return result;
     }
@@ -531,7 +560,7 @@ export class HybridComplete implements CompleteStrategy {
     });
   }
 
-  private autocompleteLabelValue(result: Completion[], context: Context) {
+  private autocompleteLabelValue(result: Completion[], context: Context): Completion[] | Promise<Completion[]> {
     if (!this.prometheusClient || !context.labelName) {
       return result;
     }

--- a/src/lang-promql/complete/index.ts
+++ b/src/lang-promql/complete/index.ts
@@ -32,24 +32,24 @@ export interface CompleteStrategy {
 
 // CompleteConfiguration should be used to customize the autocompletion.
 export interface CompleteConfiguration {
-  // Provide these settings when not using a custom PrometheusClient.
-  url?: string;
-  lookbackInterval?: number;
-  httpErrorHandler?: (error: any) => void;
-  fetchFn?: FetchFn;
-  // cache will allow user to change the configuration of the cached Prometheus client (which is used by default)
-  cache?: {
-    // maxAge is the maximum amount of time that a cached completion item is valid before it needs to be refreshed.
-    // It is in milliseconds. Default value:  300 000 (5min)
-    maxAge: number;
+  remote: {
+    // Provide these settings when not using a custom PrometheusClient.
+    url?: string;
+    lookbackInterval?: number;
+    httpErrorHandler?: (error: any) => void;
+    fetchFn?: FetchFn;
+    // cache will allow user to change the configuration of the cached Prometheus client (which is used by default)
+    cache?: {
+      // maxAge is the maximum amount of time that a cached completion item is valid before it needs to be refreshed.
+      // It is in milliseconds. Default value:  300 000 (5min)
+      maxAge: number;
+    };
+    // When providing this custom PrometheusClient, the settings above will not be used.
+    prometheusClient?: PrometheusClient;
   };
-
   // maxMetricsMetadata is the maximum limit of the number of metrics in Prometheus.
   // Under this limit, it allows the completion to get the metadata of the metrics.
   maxMetricsMetadata?: number;
-
-  // When providing this custom PrometheusClient, the settings above will not be used.
-  prometheusClient?: PrometheusClient;
 
   // When providing this custom CompleteStrategy, the settings above will not be used.
   completeStrategy?: CompleteStrategy;
@@ -59,13 +59,15 @@ export function newCompleteStrategy(conf?: CompleteConfiguration): CompleteStrat
   if (conf?.completeStrategy) {
     return conf.completeStrategy;
   }
-
-  if (conf?.prometheusClient) {
-    return new HybridComplete(conf.prometheusClient, conf.maxMetricsMetadata);
+  if (conf?.remote.prometheusClient) {
+    return new HybridComplete(conf.remote.prometheusClient, conf.maxMetricsMetadata);
   }
-  if (conf?.url) {
+  if (conf?.remote.url) {
     return new HybridComplete(
-      new CachedPrometheusClient(new HTTPPrometheusClient(conf.url, conf.httpErrorHandler, conf.lookbackInterval, conf.fetchFn), conf.cache?.maxAge),
+      new CachedPrometheusClient(
+        new HTTPPrometheusClient(conf.remote.url, conf.remote.httpErrorHandler, conf.remote.lookbackInterval, conf.remote.fetchFn),
+        conf.remote.cache?.maxAge
+      ),
       conf.maxMetricsMetadata
     );
   }

--- a/src/lang-promql/complete/index.ts
+++ b/src/lang-promql/complete/index.ts
@@ -34,8 +34,8 @@ export interface CompleteStrategy {
 // CompleteConfiguration should be used to customize the autocompletion.
 export interface CompleteConfiguration {
   remote?: PrometheusConfig | PrometheusClient;
-  // maxMetricsMetadata is the maximum limit of the number of metrics in Prometheus.
-  // Under this limit, it allows the completion to get the metadata of the metrics.
+  // maxMetricsMetadata is the maximum number of metrics in Prometheus for which metadata is fetched.
+  // If the number of metrics exceeds this limit, no metric metadata is fetched at all.
   maxMetricsMetadata?: number;
   // enricher is a function that will allow user to enrich the current completion by adding a custom one
   enricher?: EnrichCompletionHandler;

--- a/src/lang-promql/index.ts
+++ b/src/lang-promql/index.ts
@@ -21,5 +21,5 @@
 // SOFTWARE.
 
 export { PrometheusClient } from './client';
-export { CompleteConfiguration } from './complete';
+export { CompleteConfiguration, ContextKind, EnrichCompletionHandler } from './complete';
 export { PromQLExtension, promQLSyntax } from './promql';


### PR DESCRIPTION
This PR provides a way to inject a custom completion. It won't override the current completion but will enrich it instead.
It will be possible to trigger the custom completion for a certain kind of completion (like only when the system will autocomplete the aggregation)

related to https://github.com/prometheus/prometheus/pull/8174