### PR TITLE
Add metricNames(prefix?: string) method to prometheus interface

### DIFF
--- a/src/lang-promql/client/prometheus.ts
+++ b/src/lang-promql/client/prometheus.ts
@@ -43,6 +43,11 @@ export interface PrometheusClient {
   metricMetadata(): Promise<Record<string, MetricMetadata[]>>;
 
   series(metricName: string): Promise<Map<string, string>[]>;
+
+  // metricNames returns a list of suggestions for the metric name given the `prefix`.
+  // Note that the returned list can be a superset of those suggestions for the prefix (i.e., including ones without the
+  // prefix), as codemirror will filter these out when displaying suggestions to the user.
+  metricNames(prefix?: string): Promise<string[]>;
 }
 
 interface APIResponse<T> {
@@ -196,6 +201,10 @@ export class HTTPPrometheusClient implements PrometheusClient {
     });
   }
 
+  metricNames(prefix?: string): Promise<string[]> {
+    return this.labelValues('__name__');
+  }
+
   private fetchAPI<T>(resource: string): Promise<T> {
     return this.fetchFn(this.url + resource)
       .then((res) => {
@@ -336,5 +345,9 @@ export class CachedPrometheusClient implements PrometheusClient {
       this.cache.setAssociations(metricName, series);
       return series;
     });
+  }
+
+  metricNames(prefix?: string): Promise<string[]> {
+    return this.labelValues('__name__');
   }
 }

--- a/src/lang-promql/complete/hybrid.test.ts
+++ b/src/lang-promql/complete/hybrid.test.ts
@@ -41,38 +41,38 @@ describe('analyzeCompletion test', () => {
       title: 'simple metric autocompletion',
       expr: 'go_',
       pos: 3, // cursor is at the end of the expr
-      expectedContext: [{ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: 'go_' }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
     },
     {
       title: 'metric/function/aggregation autocompletion',
       expr: 'sum()',
       pos: 4,
-      expectedContext: [{ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: '' }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
     },
     {
       title: 'metric/function/aggregation autocompletion 2',
       expr: 'sum(rat)',
       pos: 7,
-      expectedContext: [{ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: 'rat' }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
     },
     {
       title: 'metric/function/aggregation autocompletion 3',
       expr: 'sum(rate())',
       pos: 9,
-      expectedContext: [{ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: '' }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
     },
     {
       title: 'metric/function/aggregation autocompletion 4',
       expr: 'sum(rate(my_))',
       pos: 12,
-      expectedContext: [{ kind: ContextKind.MetricName }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: 'my_' }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation }],
     },
     {
       title: 'autocomplete binOp modifier or metric',
       expr: 'metric_name / ignor',
       pos: 19,
       expectedContext: [
-        { kind: ContextKind.MetricName },
+        { kind: ContextKind.MetricName, metricName: 'ignor' },
         { kind: ContextKind.Function },
         { kind: ContextKind.Aggregation },
         { kind: ContextKind.BinOpModifier },
@@ -83,7 +83,7 @@ describe('analyzeCompletion test', () => {
       expr: 'sum(http_requests_total{method="GET"} / o)',
       pos: 41,
       expectedContext: [
-        { kind: ContextKind.MetricName },
+        { kind: ContextKind.MetricName, metricName: 'o' },
         { kind: ContextKind.Function },
         { kind: ContextKind.Aggregation },
         { kind: ContextKind.BinOpModifier },

--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -122,15 +122,6 @@ function getMetricNameInVectorSelector(tree: SyntaxNode, state: EditorState): st
   return state.sliceDoc(currentNode.from, currentNode.to);
 }
 
-// getMetricIdentifierValue returns the value of the encapsulating MetricIdentifier for the given tree
-function getMetricIdentifierValue(tree: SyntaxNode, state: EditorState): string {
-  let currentNode: SyntaxNode | null = walkBackward(tree, MetricIdentifier);
-  if (!currentNode) {
-    return '';
-  }
-  return state.sliceDoc(currentNode.from, currentNode.to);
-}
-
 function arrayToCompletionResult(data: Completion[], from: number, to: number, includeSnippet = false, span = true): CompletionResult {
   const options = data;
   if (includeSnippet) {
@@ -260,7 +251,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         // this case is normally impossible since by definition, the identifier has 3 parents,
         // and in Lexer, there is always a default parent in top of everything.
         result.push(
-          { kind: ContextKind.MetricName, metricName: getMetricIdentifierValue(node, state) },
+          { kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to) },
           { kind: ContextKind.Function },
           { kind: ContextKind.Aggregation }
         );
@@ -272,7 +263,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         if (parent.type.id === BinaryExpr && !containsAtLeastOneChild(parent, 0)) {
           // We are likely in the case 1 or 5
           result.push(
-            { kind: ContextKind.MetricName, metricName: getMetricIdentifierValue(node, state) },
+            { kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to) },
             { kind: ContextKind.Function },
             { kind: ContextKind.Aggregation },
             { kind: ContextKind.BinOpModifier }
@@ -282,7 +273,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         }
       } else {
         result.push(
-          { kind: ContextKind.MetricName, metricName: getMetricIdentifierValue(node, state) },
+          { kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to) },
           { kind: ContextKind.Function },
           { kind: ContextKind.Aggregation }
         );
@@ -336,11 +327,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
       result.push({ kind: ContextKind.Duration });
       break;
     case FunctionCallBody:
-      result.push(
-        { kind: ContextKind.MetricName, metricName: getMetricIdentifierValue(node, state) },
-        { kind: ContextKind.Function },
-        { kind: ContextKind.Aggregation }
-      );
+      result.push({ kind: ContextKind.MetricName, metricName: '' }, { kind: ContextKind.Function }, { kind: ContextKind.Aggregation });
       break;
     case Neq:
       if (node.parent?.type.id === MatchOp) {


### PR DESCRIPTION
This change adds a `metricNames(prefix?: string)` method to the `PrometheusClient` interface and modifies the hybrid autocomplete engine to use this new method when fetching autocomplete results for a metric name.  Importantly, it passes the currently typed metric identifier (i.e., the `prefix`) to the client, which allows for more sophisticated custom clients.

The default client simply calls `labelValues('__name__')` for now, as it did previously.

This change was discussed in https://github.com/prometheus-community/codemirror-promql/issues/84