### PR TITLE
provide getter and setter to manipulate the different object provided by the lib

### DIFF
--- a/src/lang-promql/complete/hybrid.ts
+++ b/src/lang-promql/complete/hybrid.ts
@@ -444,6 +444,10 @@ export class HybridComplete implements CompleteStrategy {
     this.maxMetricsMetadata = maxMetricsMetadata;
   }
 
+  getPrometheusClient(): PrometheusClient | undefined {
+    return this.prometheusClient;
+  }
+
   promQL(context: CompletionContext): Promise<CompletionResult | null> | CompletionResult | null {
     const { state, pos } = context;
     const tree = syntaxTree(state).resolve(pos, -1);

--- a/src/lang-promql/promql.ts
+++ b/src/lang-promql/promql.ts
@@ -63,7 +63,7 @@ export const promQLLanguage = LezerLanguage.define({
  */
 export class PromQLExtension {
   private complete: CompleteStrategy;
-  private readonly lint: LintStrategy;
+  private lint: LintStrategy;
   private enableCompletion: boolean;
   private enableLinter: boolean;
 
@@ -79,9 +79,22 @@ export class PromQLExtension {
     return this;
   }
 
+  getComplete(): CompleteStrategy {
+    return this.complete;
+  }
+
   activateCompletion(activate: boolean): PromQLExtension {
     this.enableCompletion = activate;
     return this;
+  }
+
+  setLinter(linter: LintStrategy): PromQLExtension {
+    this.lint = linter;
+    return this;
+  }
+
+  getLinter(): LintStrategy {
+    return this.lint;
   }
 
   activateLinter(activate: boolean): PromQLExtension {


### PR DESCRIPTION
It's a way to fix #124.
The lib should not provide the way to warm a cache, just enough flexibility if someone would like too. And from my point of view, having a way to get the instance of the cached prometheus client should be good. Because then to "warm" it, you just need to get the instance of the prometheusClient and then manually perform the retrieve of the metric list for example