### PR TITLE
fetch series with post method

### DIFF
--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -46,6 +46,8 @@ export function mockPrometheusServer() {
     .replyWithFile(200, __dirname + '/metadata.json')
     .get('/api/v1/series')
     .query(true)
+    .replyWithFile(200, __dirname + '/alertmanager_alerts_series.json')
+    .post('/api/v1/series')
     .replyWithFile(200, __dirname + '/alertmanager_alerts_series.json');
 }
 


### PR DESCRIPTION
ref: https://prometheus.io/docs/prometheus/latest/querying/api/#finding-series-by-label-matchers
> You can URL-encode these parameters directly in the request body by using the POST method and Content-Type: application/x-www-form-urlencoded header. This is useful when specifying a large or dynamic number of series selectors that may breach server-side URL character limits.