### PR TITLE
Update license to Apache 2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,4 +253,4 @@ or [send a pull request](https://github.com/prometheus-community/codemirror-prom
 
 ## License
 
-[MIT](./LICENSE)
+[Apache 2.0](./LICENSE)


### PR DESCRIPTION
Recently the license of this repo was changed to Apache 2.0, but I noticed that the README still showed MIT.